### PR TITLE
Fix multitype index mapping restoration

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -146,29 +146,33 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback){
         for(var index in data){
             var mappings = data[index]['mappings'];
             for(var key in mappings){
-                var mapping  =  {};
-                mapping[key] = mappings[key];
-                var url = self.baseUrl + '/' + key + '/_mapping';
+                var mapping  = mappings[key];
+                var mappingUrl = self.baseUrl + '/_mapping' + '/' + key;
+                var mappingCreationCallback = function(mappingUrl){
+                    return function (err, response){
+                        var payload = {
+                            url: mappingUrl,
+                            body: JSON.stringify(mapping),
+                        };
+                        request.put(payload, function(err, response){ // upload the mapping
+                            started--;
+                            if(err){
+                                var bodyError = jsonParser.parse(response.body).error;
+                                if(bodyError){ err = bodyError; }
+                            }
+                            if(started === 0){
+                                self.haveSetMapping = true;
+                                callback(err, count);
+                            }
+                        });
+                    };
+                };
                 started++;
                 count++;
-                request.put(self.baseUrl, function(err, response){ // ensure the index exists
-                    var payload = {
-                        url: url,
-                        body: JSON.stringify(mapping),
-                    };
-                    request.put(payload, function(err, response){ // upload the mapping
-                        started--;
-                        if(err){
-                            var bodyError = jsonParser.parse(response.body).error;
-                            if(bodyError){ err = bodyError; }
-                        }
-                        if(started === 0){
-                            self.haveSetMapping = true;
-                            callback(err, count);
-                        }
-                    });
-                });
-            }
+                // Ensure the index exists
+                // and create the mapping as a callback
+                request.put(self.baseUrl, mappingCreationCallback(mappingUrl));
+             }
         }
     }
 };


### PR DESCRIPTION
Tested againts the latest version of ES 1.4.1.
Without this fix, the url that is defined in the
callback does not iterate properly through all the
types because of a race condition.

Also the Put Mapping API expects a dictionary like
{"properties": { "field1": ..., "field2": ...}}
The previous formatting used 'key' to prefix the dict
making all subsequent calls to ES return a 400.

Moreover, the URL used is incorrect, according to ES
docs it needs to be {index}/_mapping/{type} and not
{index}/{type}/_mapping