### PR TITLE
fix elasticsearch urls in sub-paths

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -294,9 +294,6 @@ function scrollResultSet(that, callback) {
         searchUrl = baseUrl;
     } else {
         searchUrl = baseUrl.substr(0, baseUrl.lastIndexOf('/'));
-        if(searchUrl.split('/').length > 3){ // indicates a request for a index/type search
-            searchUrl = searchUrl.substr(0, searchUrl.lastIndexOf('/'));
-        }
     }
 
     var scrollRequest = {


### PR DESCRIPTION
This PR fixes support for elasticsearch urls that are in sub-paths (not necessarily in root) e.g. "http://example.com/elasticsearch/index1"