### PR TITLE
Skip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
                     it will result in the entire batch not being written. 
                     Mostly used when you don't care too much if you lose some
                     data when importing but rather have speed.
+--skip
+                    Integer containing the number of rows you wish to skip ahead from the input transport.  When importing a large index, things can go wrong, be it connectivity, crashes, someone forgetting to `screen`, etc.  This allows you to start the dump again from the last known line written (as logged by the `offset` in the output).  Please be advised that since no sorting is specified when the dump is initially created, there's no real way to guarantee that the skipped rows have already been written/parsed.  This is more of an option for when you want to get most data as possible in the index without concern for losing some rows in the process, similar to the `timeout` option.
 --help
                     This page
 ```

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -21,7 +21,8 @@ var defaults = {
   'bulk-use-output-index-name': false,
   searchBody: 	   '{"query": { "match_all": {} } }',
   timeout:         null,
-};
+  skip:            null,
+}
 
 var options = {};
 

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -89,6 +89,11 @@ elasticdump.prototype.dump = function(callback, continuing, limit, offset, total
 
     if(continuing !== true){
       self.log('starting dump');
+
+      if(self.options.skip){
+        self.log('Warning: skipping ' + self.options.skip + ' rows.');
+        self.log("  * skipping doesn't guarantee that the skipped rows have already been written, please refer to the README.");
+      }
     }
 
     self.input.get(limit, offset, function(err, data){

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -9,6 +9,7 @@ var elasticsearch = function (parent, baseUrl) {
     this.parent             = parent;
     this.lastScrollId       = null;
     this.totalSearchResults = 0;
+    this.hasSkipped         = 0;
 };
 
 // accept callback
@@ -351,7 +352,27 @@ function scrollResultSet(that, callback) {
             if (hits.length === 0) {
                 self.lastScrollId = null;
             }
-            callback(err, hits);
+
+            // are we skipping and we have hits?
+            if(self.parent.options.skip !== null && hits.length > 0 && self.hasSkipped < self.parent.options.skip) {
+                // lets remove hits until we reach the skip number
+                while(hits.length > 0 && self.hasSkipped < self.parent.options.skip) {
+                    self.hasSkipped++;
+                    hits.splice(0, 1);
+                }
+
+                if(hits.length > 0) {
+                    // we have some hits after skipping, lets callback
+                    callback(err, hits);
+                } else {
+                    // we skipped, but now we don't have any hits,
+                    // scroll again for more data if possible
+                    scrollResultSet(that, callback);
+                }
+            } else {
+                // not skipping or done skipping
+                callback(err, hits);
+            }
         }
     });
 }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -62,17 +62,17 @@ elasticsearch.prototype.getData = function (limit, offset, callback){
                   self.parent.options.scrollTime +
                   "&size=" + shardedLimit;
 
-        /* Original, but now set as a default from bin/elasticdump */
-        /*
-            searchBody = {
-                "query": {
-                    "match_all": {}
-                },
-                "size": shardedLimit
-            };
-        */
+            /* Original, but now set as a default from bin/elasticdump */
+            /*
+                searchBody = {
+                    "query": {
+                        "match_all": {}
+                    },
+                    "size": shardedLimit
+                };
+            */
 
-        searchBody.size = shardedLimit;
+            searchBody.size = shardedLimit;
 
             searchRequest = {
                 "uri": uri,
@@ -332,12 +332,12 @@ function scrollResultSet(that, callback) {
         var hits = body.hits.hits;
 
         if(self.parent.options.delete === true && hits.length > 0) {
-            var stated = 0;
+            var started = 0;
             hits.forEach(function(elem){
-                stated++;
+                started++;
                 self.del(elem, function(){
-                    stated--;
-                    if(stated === 0){
+                    started--;
+                    if(started === 0){
                         self.reindex(function(err){
                             if (hits.length === 0) {
                                 self.lastScrollId = null;

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -28,6 +28,7 @@ file.prototype.get = function(limit, offset, callback){
 
 file.prototype.getLines = function(limit, offset, callback, data){
   var self = this;
+
   if(!data){ data = []; }
   
   if(data.length >= limit){
@@ -36,9 +37,17 @@ file.prototype.getLines = function(limit, offset, callback, data){
     self.reader.nextLine(function(line){
       if(line[0] == ','){ line = line.substring(1); }
       line = line.trim();
+
       if(line.length > 1){ 
-        data.push( JSON.parse(line) );
+        // are we skipping?
+        if(self.parent.options.skip === null || self.getLineCounter >= self.parent.options.skip) {
+          // no, lets push the data
+          data.push( JSON.parse(line) );
+        }
+
+        self.getLineCounter++;
       }
+
       self.getLines(limit, offset, callback, data);
     });
   }else{

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -40,7 +40,7 @@ file.prototype.getLines = function(limit, offset, callback, data){
 
       if(line.length > 1){ 
         // are we skipping?
-        if(self.parent.options.skip === null || self.getLineCounter >= self.parent.options.skip) {
+        if(!self.parent.options.skip || (self.parent.options.skip !== null && self.getLineCounter >= self.parent.options.skip)) {
           // no, lets push the data
           data.push( JSON.parse(line) );
         }

--- a/test/test.js
+++ b/test/test.js
@@ -585,3 +585,4 @@ describe("ELASTICDUMP", function(){
   });
 
 });
+

--- a/test/test.js
+++ b/test/test.js
@@ -585,4 +585,3 @@ describe("ELASTICDUMP", function(){
   });
 
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -415,6 +415,33 @@ describe("ELASTICDUMP", function(){
         });
       });
     });
+
+    it('can skip', function(done) {
+      this.timeout(testTimeout);
+      var options = {
+        limit:  100,
+        offset: 0,
+        debug:  false,
+        type:   'data',
+        input: '/tmp/out.json',
+        output: baseUrl + '/destination_index',
+        scrollTime: '10m',
+        skip: 250
+      };
+
+      var dumper = new elasticdump(options.input, options.output, options);
+
+      dumper.dump(function(){
+        var url = baseUrl + "/destination_index/_search";
+        request.get(url, function(err, response, body){
+          should.not.exist(err);
+          body = JSON.parse(body);
+          // skips 250 so 250 less in there
+          body.hits.total.should.equal(seedSize - 250);
+          done();
+        });
+      });
+    });
   });
 
   describe("all es to file", function(){

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,32 @@ describe("ELASTICDUMP", function(){
       });
     });
 
+    it('can skip', function(done) {
+      this.timeout(testTimeout);
+      var options = {
+        limit:  100,
+        offset: 0,
+        debug:  false,
+        type:   'data',
+        input:  baseUrl + '/source_index',
+        output: baseUrl + '/destination_index',
+        scrollTime: '10m',
+        skip: 250
+      };
+
+      var dumper = new elasticdump(options.input, options.output, options);
+
+      dumper.dump(function(){
+        var url = baseUrl + "/destination_index/_search";
+        request.get(url, function(err, response, body){
+          should.not.exist(err);
+          body = JSON.parse(body);
+          body.hits.total.should.equal(seedSize - 250);
+          done();
+        });
+      });
+    });
+
     it('works for index/types', function(done){
       this.timeout(testTimeout);
       var options = {


### PR DESCRIPTION
Adds the `--skip` option.

It's an integer containing the number of rows you wish to skip ahead from the input transport.

Reasoning: when importing a large index, things can go wrong, be it connectivity, crashes, someone forgetting to `screen`, etc.  This allows you to start the dump again from the last known line written (as logged by the `offset` in the output).