### PR TITLE
Help and input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
                     it will result in the entire batch not being written. 
                     Mostly used when you don't care too much if you lose some
                     data when importing but rather have speed.
+--help
+                    This page
 ```
 
 ## Elasticsearch's scan and scroll method

--- a/README.md
+++ b/README.md
@@ -43,40 +43,105 @@ You can then do things like:
 
 ```bash
 # Copy an index from production to staging with mappings:
-elasticdump --input=http://production.es.com:9200/my_index --output=http://staging.es.com:9200/my_index --type=mapping
-elasticdump --input=http://production.es.com:9200/my_index --output=http://staging.es.com:9200/my_index --type=data
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=http://staging.es.com:9200/my_index \
+  --type=mapping
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=http://staging.es.com:9200/my_index \
+  --type=data
 
 # Backup index data to a file:
-elasticdump --input=http://production.es.com:9200/my_index --output=/data/my_index_mapping.json --type=mapping
-elasticdump --input=http://production.es.com:9200/my_index --output=/data/my_index.json --type=data
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=/data/my_index_mapping.json \
+  --type=mapping
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=/data/my_index.json \
+  --type=data
 
 # Backup and index to a gzip using stdout:
-elasticdump --input=http://production.es.com:9200/my_index --output=$ | gzip > /data/my_index.json.gz
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=$ \
+  | gzip > /data/my_index.json.gz
 
 # Backup ALL indices, then use Bulk API to populate another ES cluster:
-elasticdump --all=true --input=http://production-a.es.com:9200/ --output=/data/production.json
-elasticdump --bulk=true --input=/data/production.json --output=http://production-b.es.com:9200/
+elasticdump \
+  --all=true \
+  --input=http://production-a.es.com:9200/ \
+  --output=/data/production.json
+elasticdump \
+  --bulk=true \
+  --input=/data/production.json \
+  --output=http://production-b.es.com:9200/
 
 # Backup the results of a query to a file
-elasticdump --input=http://production.es.com:9200/my_index --output=query.json --searchBody '{"query":{"term":{"username": "admin"}}}'
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=query.json \
+  --searchBody '{"query":{"term":{"username": "admin"}}}'
 ```
 
 ## Options
 
-- `--input` (required) (see above)
-- `--output` (required) (see above)
-- `--limit` how many ojbects to move in bulk per operation (default: 100)
-- `--debug` display the elasticsearch commands being used (default: false)
-- `--type` what are we exporting? (default: data, options: [data, mapping])
-- `--delete` delete documents one-by-one from the input as they are moved (will not delete the source index) (default: false)
-- `--searchBody` preform a partial extract based on search results (when ES is the `input`, default: '{"query": { "match_all": {} } }')
-- `--all` load/store documents from ALL indices (default: false)
-- `--bulk` leverage elasticsearch Bulk API when writing documents (default: false)
-- `--ignore-errors` will continue the read/write loop on write error (default: false)
-- `--scrollTime` Time the nodes will hold the requested search in order. (default: 10m)
-- `--maxSockets` How many simultanius HTTP requests can this process make? (default: 5 [node <= v0.10.x] / Infinity [node >= v0.11.x] )
-- `--bulk-use-output-index-name` Force use of destination index name (actually the actual output URL) as destination while bulk writing to ES. Allows leveraging  Bulk API copying data inside the same elasticsearch instance. (default: false)
-- `--timeout` Integer containing the number of milliseconds to wait for a request to respond before aborting the request.  Passed directly to the `request` library.  If used in bulk writing, it will result in the entire batch not being written.  Mostly used when you don't care too much if you lose some data when importing but rather have speed.
+```
+Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
+
+--input                       
+                    Source location (required)
+--output                      
+                    Destination location (required)
+--limit                       
+                    How many objects to move in bulk per operation 
+                    (default: 100)
+--debug                       
+                    Display the elasticsearch commands being used 
+                    (default: false)
+--type                        
+                    What are we exporting? 
+                    (default: data, options: [data, mapping])
+--delete                      
+                    Delete documents one-by-one from the input as they are 
+                    moved.  Will not delete the source index
+                    (default: false)
+--searchBody                  
+                    Preform a partial extract based on search results 
+                    (when ES is the input, 
+                      default: '{"query": { "match_all": {} } }')
+--all                         
+                    Load/store documents from ALL indexes 
+                    (default: false)
+--bulk                        
+                    Leverage elasticsearch Bulk API when writing documents 
+                    (default: false)
+--ignore-errors               
+                    Will continue the read/write loop on write error 
+                    (default: false)
+--scrollTime                  
+                    Time the nodes will hold the requested search in order. 
+                    (default: 10m)
+--maxSockets                  
+                    How many simultaneous HTTP requests can we process make? 
+                    (default: 
+                      5 [node <= v0.10.x] / 
+                      Infinity [node >= v0.11.x] )
+--bulk-use-output-index-name  
+                    Force use of destination index name (the actual output URL)
+                    as destination while bulk writing to ES. Allows 
+                    leveraging Bulk API copying data inside the same 
+                    elasticsearch instance. 
+                    (default: false)
+--timeout                     
+                    Integer containing the number of milliseconds to wait for 
+                    a request to respond before aborting the request. Passed 
+                    directly to the request library. If used in bulk writing, 
+                    it will result in the entire batch not being written. 
+                    Mostly used when you don't care too much if you lose some
+                    data when importing but rather have speed.
+```
 
 ## Elasticsearch's scan and scroll method
 Elasticsearch provides a scan and scroll method to fetch all documents of an index. This method is much safer to use since

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -13,21 +13,21 @@ var defaults = {
   all:             false,
   bulk:            false,
   maxSockets:      null,
-  input:           'http://127.0.0.1:9200/sourceIndex',
-  output:          'http://127.0.0.1:9200/destinationIndex',
+  input:           null,
+  output:          null,
   format:          '',
   'ignore-errors': false,
   scrollTime:      '10m',
   'bulk-use-output-index-name': false,
   searchBody: 	   '{"query": { "match_all": {} } }',
   timeout:         null,
-}
+};
 
 var options = {};
 
 for(var i in defaults){
   options[i] = defaults[i];
-  if(argv[i] != null){
+  if(argv[i]){
     options[i] = argv[i];
   }
   if(options[i] === 'true' ){ options[i] = true; }
@@ -49,12 +49,17 @@ var log = function(type, message){
     message = (new Date().toUTCString()) + " | " + message;
   }
   console.log(message);
+};
+
+if(argv.help === true){
+  var helpText = require('fs').readFileSync( __dirname + '/../lib/help.txt');
+  console.log(String(helpText));
+}else{
+  var dumper = new elasticdump(options.input, options.output, options);
+
+  dumper.on('log',   function(message){ log('log',   message); });
+  dumper.on('debug', function(message){ log('debug', message); });
+  dumper.on('error', function(error){   log('log',   error.message || JSON.stringify(error)); });
+
+  dumper.dump();
 }
-
-var dumper = new elasticdump(options.input, options.output, options);
-
-dumper.on('log',   function(message){ log('log',   message) })
-dumper.on('debug', function(message){ log('debug', message) })
-dumper.on('error', function(error){   log('log',   error.message || JSON.stringify(error)) })
-
-dumper.dump();

--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -14,12 +14,12 @@ var defaults = {
   debug:      true,
   parallel:   1,
   match:      '^.*$',
-  input:      'http://127.0.0.1:9200',
-  output:     '/tmp/elasticdump',
+  input:      null,
+  output:     null,
   scrollTime: '10m',
   limit:      100,
   offset:     100,
-}
+};
 
 var options = {};
 var matchedIndexes = [];
@@ -40,11 +40,11 @@ var log = function(type, message){
     message = (new Date().toUTCString()) + " | " + message;
   }
   console.log(message); 
-}
+};
 
 for(var i in defaults){
   options[i] = defaults[i];
-  if(argv[i] != null){ 
+  if(argv[i]){ 
     options[i] = argv[i];
   }
   if(options[i] === 'true' ){ options[i] = true; }
@@ -56,7 +56,7 @@ request.get(options.input + '/_aliases', function(err, response){
   response = JSON.parse(response.body);
   for(var index in response){
     var matches = index.match(new RegExp(options.match, "i"));
-    if(matches != null){
+    if(matches){
       matchedIndexes.push(index);
     }
   }
@@ -71,20 +71,20 @@ var work = function(){
   if(complete == matchedIndexes.length){
     log('debug', ' all done ');
     log('debug', ' bye ');
-    process.exit()
+    process.exit();
   }else if(working == options.parallel){
     setTimeout(work, sleepTime);
   }else{
     dump();
     setTimeout(work, sleepTime);
   }
-}
+};
 
 var dump = function(){
   working++;
   var index = matchedIndexes[indexCounter];
   
-  if(index == null){
+  if(!index){
     working--;
     return;
   }
@@ -124,4 +124,4 @@ var dump = function(){
     complete++;
   });
   
-}
+};

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -53,6 +53,8 @@ Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
                     it will result in the entire batch not being written. 
                     Mostly used when you don't care too much if you lose some
                     data when importing but rather have speed.
+--help
+                    This page
 
 Examples: 
 

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -1,0 +1,102 @@
+elasticdump: Import and export tools for elasticsearch
+
+Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
+
+--input                       
+                    Source location (required)
+--output                      
+                    Destination location (required)
+--limit                       
+                    How many objects to move in bulk per operation 
+                    (default: 100)
+--debug                       
+                    Display the elasticsearch commands being used 
+                    (default: false)
+--type                        
+                    What are we exporting? 
+                    (default: data, options: [data, mapping])
+--delete                      
+                    Delete documents one-by-one from the input as they are 
+                    moved.  Will not delete the source index
+                    (default: false)
+--searchBody                  
+                    Preform a partial extract based on search results 
+                    (when ES is the input, 
+                      default: '{"query": { "match_all": {} } }')
+--all                         
+                    Load/store documents from ALL indexes 
+                    (default: false)
+--bulk                        
+                    Leverage elasticsearch Bulk API when writing documents 
+                    (default: false)
+--ignore-errors               
+                    Will continue the read/write loop on write error 
+                    (default: false)
+--scrollTime                  
+                    Time the nodes will hold the requested search in order. 
+                    (default: 10m)
+--maxSockets                  
+                    How many simultaneous HTTP requests can we process make? 
+                    (default: 
+                      5 [node <= v0.10.x] / 
+                      Infinity [node >= v0.11.x] )
+--bulk-use-output-index-name  
+                    Force use of destination index name (the actual output URL)
+                    as destination while bulk writing to ES. Allows 
+                    leveraging Bulk API copying data inside the same 
+                    elasticsearch instance. 
+                    (default: false)
+--timeout                     
+                    Integer containing the number of milliseconds to wait for 
+                    a request to respond before aborting the request. Passed 
+                    directly to the request library. If used in bulk writing, 
+                    it will result in the entire batch not being written. 
+                    Mostly used when you don't care too much if you lose some
+                    data when importing but rather have speed.
+
+Examples: 
+
+# Copy an index from production to staging with mappings:
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=http://staging.es.com:9200/my_index \
+  --type=mapping
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=http://staging.es.com:9200/my_index \
+  --type=data
+
+# Backup index data to a file:
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=/data/my_index_mapping.json \
+  --type=mapping
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=/data/my_index.json \
+  --type=data
+
+# Backup and index to a gzip using stdout:
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=$ \
+  | gzip > /data/my_index.json.gz
+
+# Backup ALL indices, then use Bulk API to populate another ES cluster:
+elasticdump \
+  --all=true \
+  --input=http://production-a.es.com:9200/ \
+  --output=/data/production.json
+elasticdump \
+  --bulk=true \
+  --input=/data/production.json \
+  --output=http://production-b.es.com:9200/
+
+# Backup the results of a query to a file
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=query.json \
+  --searchBody '{"query":{"term":{"username": "admin"}}}'
+
+------------------------------------------------------------------------------
+Learn more @ https://github.com/taskrabbit/elasticsearch-dump


### PR DESCRIPTION
- allow for help from `--help`.
- validate that the user provides `--input` and `--output`.  Don't use defaults here. 

![screen shot 2015-01-28 at 10 22 33 am](https://cloud.githubusercontent.com/assets/303226/5943923/a48e12e2-a6d7-11e4-9956-b52e9c6b218d.png)
