### PR TITLE
exit codes and blocking on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ node_js:
   # - "0.8"
   - "0.10"
   - "0.11"
+  - "0.12"
+  - "iojs"
 branches:
   only:
     - master

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -22,7 +22,7 @@ var defaults = {
   searchBody: 	   '{"query": { "match_all": {} } }',
   timeout:         null,
   skip:            null,
-}
+};
 
 var options = {};
 
@@ -62,5 +62,11 @@ if(argv.help === true){
   dumper.on('debug', function(message){ log('debug', message); });
   dumper.on('error', function(error){   log('log',   error.message || JSON.stringify(error)); });
 
-  dumper.dump();
+  dumper.dump(function(err, total_writes){
+    if(err){
+      process.exit(1);
+    }else{
+      process.exit(0);
+    }
+  });
 }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -93,6 +93,11 @@ elasticsearch.prototype.getData = function (limit, offset, callback){
 
                 var body = jsonParser.parse(response.body);
                 self.lastScrollId = body._scroll_id;
+                if(self.lastScrollId === undefined){
+                    err = new Error("Unable to obtain scrollId; This tends to indicate an error with your index(es)");
+                    callback(err, []);
+                    return;
+                }
                 self.totalSearchResults = body.hits.total;
 
                 scrollResultSet(self, callback);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Evan Tahler <evantahler@gmail.com>",
   "name": "elasticdump",
   "description": "import and export tools for elasticsearch",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/taskrabbit/elasticsearch-dump.git"

--- a/test/test.js
+++ b/test/test.js
@@ -330,7 +330,7 @@ describe("ELASTICDUMP", function(){
       var dumper_a = new elasticdump(options.input, options.output, options);
       var dumper_b = new elasticdump(options.input, options.output, options);
 
-      dumper_a.dump(function(total_writes){
+      dumper_a.dump(function(err, total_writes){
         var url = baseUrl + "/destination_index/_search";
         request.get(url, function(err, response, body){
           should.not.exist(err);
@@ -338,7 +338,7 @@ describe("ELASTICDUMP", function(){
           body.hits.total.should.equal(seedSize);
           total_writes.should.equal(seedSize);
 
-          dumper_b.dump(function(total_writes){
+          dumper_b.dump(function(err, total_writes){
             var url = baseUrl + "/destination_index/_search";
             request.get(url, function(err, response, body){
               should.not.exist(err);


### PR DESCRIPTION
- Change exit code status when process exits with error (more unix-y)
- extend the `ignore-errors` option to also exit early when there is a READ error
  - you san still pass `--ignore-errors` to the program to keep trying even with errors
- Add better error messaging when you are attempting to dump an empty cluster of data
- Test with the new node v12 and iojs 