### PR TITLE
allow specification of whether or not to update existing documents in destination

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -25,6 +25,7 @@ var defaults = {
   timeout:         null,
   skip:            null,
   toLog:           null,
+  update:          true,
 };
 
 var options = {};

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -17,8 +17,14 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     (default: data, options: [data, mapping])
 --delete                      
                     Delete documents one-by-one from the input as they are 
-                    moved.  Will not delete the source index
+                    moved.  Will not delete the source index.
                     (default: false)
+--update
+                    Update existing documents if they exist in the
+                    destination. When set to false, existing documents in the
+                    destination will not be overwritten. See "op_type", and /
+                    or bulk operation "create" vs "index".
+                    (default: true)
 --searchBody                  
                     Preform a partial extract based on search results 
                     (when ES is the input, 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -1,5 +1,6 @@
 var request = require('request');
 var jsonParser = require('../jsonparser.js');
+var querystring = require("querystring");
 
 var elasticsearch = function (parent, baseUrl) {
     if(baseUrl.substr(-1) === '/') {
@@ -176,6 +177,7 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback){
     var self = this;
     var error = null;
     var writes = 0;
+    var doUpdate = self.parent.options['update'] === true;
     if (self.parent.options.bulk === true){
         var thisUrl = self.baseUrl + "/_bulk";
         var payload = {
@@ -185,7 +187,11 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback){
         };
         var useOutputIndexName = self.parent.options['bulk-use-output-index-name'] === true;
         data.forEach(function(elem, index, theArray) {
-            var val = "{ \"index\" : { ";
+            var val;
+            if (doUpdate)
+              val = "{ \"index\" : { ";
+            else
+              val = "{ \"create\" : { ";
             if (!useOutputIndexName) { // Not setting _index should use the one defined in URL.
               val += "\"_index\" : \"" + elem._index + "\", ";
             }
@@ -224,7 +230,12 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback){
             started++;
             var thisUrl = self.baseUrl + "/";
             if(self.parent.options.all === true){ thisUrl += elem._index + "/"; }
-            thisUrl += encodeURIComponent(elem._type) + "/" + encodeURIComponent(elem._id);
+            var params = {};
+            if (! doUpdate)
+                params.op_type = "create";
+            else
+                params.op_type = "index";
+            thisUrl += encodeURIComponent(elem._type) + "/" + encodeURIComponent(elem._id) + "?" + querystring.stringify(params);
             var payload = {
                 url:  thisUrl,
                 body: JSON.stringify(elem._source),

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "mocha": "latest",
+    "promise": "^7.0.4",
     "should": "latest"
   },
   "bin": {


### PR DESCRIPTION
We had a case in which we wanted to point the consumer to a new index for writing, and then copy the old messages into the new index.

Allowing specification of the update property allows us to fill-in-the-gaps, without worrying about overwriting new data with old data.