### PR TITLE
toLog option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
                     Provide a custom js file to us as the input transport
 --outputTransport   
                     Provide a custom js file to us as the output transport
+--toLog
+                    When using a custom outputTransport, should log lines 
+                    be appended to the output stream? 
+                    (default: true, except for `$`)
 --help
                     This page
 ```

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -24,6 +24,7 @@ var defaults = {
   'bulk-use-output-index-name': false,
   timeout:         null,
   skip:            null,
+  toLog:           null,
 };
 
 var options = {};

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -15,8 +15,11 @@ var elasticdump = function(input, output, options){
       self.options.searchBody = {"query": { "match_all": {} }, "fields": ["*"], "_source": true };
   }
 
+  if (self.options.toLog === null || self.options.toLog === undefined) {
+    self.options.toLog = true;
+  }
+
   self.validationErrors = self.validateOptions();
-  self.toLog = true;
 
   if(options.maxSockets){
     self.log('globally setting maxSockets=' + options.maxSockets);
@@ -46,7 +49,7 @@ var elasticdump = function(input, output, options){
   if(self.options.output && !self.options.outputTransport){
     if(self.options.output === "$"){
       self.outputType = 'stdio';
-      self.toLog = false;
+      self.options.toLog = false;
     }else if(isUrl(self.options.output)){
       self.outputType = 'elasticsearch';
     }else{
@@ -69,7 +72,7 @@ elasticdump.prototype.log = function(message){
 
   if(typeof self.options.logger === 'function'){
     self.options.logger(message);
-  }else if(self.toLog === true){
+  }else if(self.options.toLog === true){
     self.emit("log", message);
   }
 };

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -71,6 +71,10 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Provide a custom js file to us as the input transport
 --outputTransport   
                     Provide a custom js file to us as the output transport
+--toLog
+                    When using a custom outputTransport, should log lines 
+                    be appended to the output stream? 
+                    (default: true, except for `$`)
 --help
                     This page
 


### PR DESCRIPTION
Ability to turn of status logger when using custom transports via new `--toLog` option