### PR TITLE
Add sourceOnly and jsonLines options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ Usage: elasticdump --input [SOURCE] --output [DESTINATION] [OPTIONS]
                     Preform a partial extract based on search results 
                     (when ES is the input, 
                       default: '{"query": { "match_all": {} } }')
+--sourceOnly                  
+                    Output only the json contained within the document _source 
+                      Normal: {"_index":"","_type":"","_id":"", "_source":{SOURCE}}
+                      sourceOnly: {SOURCE}
+                      default: false
+--jsonLines                  
+                    Do not include leading '[', trailing ']' and separating ',' chararacters in output
+                      Note: Most useful in conjunction with sourceOnly to create a file of a single JSON entry per line
+                      default: false
 --all                         
                     Load/store documents from ALL indexes 
                     (default: false)

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -4,6 +4,7 @@ var argv        = require('optimist').argv;
 var util        = require('util');
 var elasticdump = require( __dirname + "/../elasticdump.js" ).elasticdump;
 
+// For future developers.  If you add options here, be sure to add the option to test suite tests where necessary
 var defaults = {
   limit:           100,
   offset:          0,
@@ -18,6 +19,8 @@ var defaults = {
   inputTransport:  null,
   outputTransport: null,
   searchBody:      null,
+  sourceOnly:      false,
+  jsonLines:       false,
   format:          '',
   'ignore-errors': false,
   scrollTime:      '10m',

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -68,23 +68,39 @@ file.prototype.set = function(data, limit, offset, callback){
       fs.unlinkSync(self.file);
     }catch(e){ }
     self.writeStream = fs.createWriteStream(self.file, { flags : 'w' });
-    self.writeStream.write("[\r\n");
+    // jsonLines means one JSON has per line.  Omit bracket if jsonLines
+    if(self.parent.options.jsonLines === false) {
+      self.writeStream.write("[\r\n");
+    }
   }
 
   if(data.length === 0){
     // close the file
-    self.writeStream.write("]\r\n");
-    setTimeout(function(){
-      try{ self.writeStream.end(); }catch(e){}
+    // jsonLines means one JSON has per line.  Omit bracket if jsonLines
+    if(self.parent.options.jsonLines === false) {
+      self.writeStream.write("]\r\n");
+    }
+    setTimeout(function() {
+      try { self.writeStream.end(); } catch(e) { };
       callback(error, data.length);
     }, 200);
   }else{   
     var ok = true;
     data.forEach(function(elem){
-      if(self.setLineCounter > 0){
-        ok = self.writeStream.write(",");
+      // Omit comma if we are outputting jsonLines
+      if(self.parent.options.jsonLines === false) {
+        if(self.setLineCounter > 0){
+          ok = self.writeStream.write(",");
+        }
       }
-      ok = self.writeStream.write(JSON.stringify(elem) + "\r\n");
+      // Select _source if sourceOnly
+      if(self.parent.options.sourceOnly === true) {
+        targetElem = elem["_source"]
+      } else {
+        targetElem = elem
+      }
+
+      ok = self.writeStream.write(JSON.stringify(targetElem) + "\r\n");
       self.setLineCounter++;
     });
     if(ok){

--- a/lib/transports/stdio.js
+++ b/lib/transports/stdio.js
@@ -72,24 +72,41 @@ stdio.prototype.set = function(data, limit, offset, callback){
   var self = this;
   var error = null;
 
-  if(self.setLineCounter === 0){
-    log("[");
+  // jsonLines means one JSON has per line.  Omit bracket if jsonLines
+  if(self.parent.options.jsonLines === false) {
+    if(self.setLineCounter === 0){
+      log("[");
+    }
   }
 
   data.forEach(function(elem){
     var comma = "";
-    if(self.setLineCounter > 0){ comma = ","; }
+    // Omit comma if we are outputting jsonLines
+    if(self.parent.options.jsonLines === false) {
+        if(self.setLineCounter > 0){ comma = ","; }
+    }
+
+    // Select _source if sourceOnly
+    if(self.parent.options.sourceOnly === true) {
+        targetElem = elem["_source"]
+    } else {
+        targetElem = elem
+    }
+
     if(self.parent.options.format.toLowerCase() === 'human'){
-      log(comma + util.inspect(elem, false, 10, true));
+      log(comma + util.inspect(targetElem, false, 10, true));
     }else{
-      log(comma + JSON.stringify(elem));
+      log(comma + JSON.stringify(targetElem));
     }
 
     self.setLineCounter++;
   });
 
-  if(data.length === 0){
-    log("]");
+  // jsonLines means one JSON has per line.  Omit bracket if jsonLines
+  if(self.parent.options.jsonLines === false) {
+    if(data.length === 0){
+      log("]");
+    }
   }
 
   callback(error, data.length);


### PR DESCRIPTION
Add ability to export to file without making a JSON array (omit "[", ",", "]")
Add ability to export only _source: {INSIDE HERE} only rather than entire ES document.