### PR TITLE
Set inputType/outputType if using custom transport

### DIFF
--- a/elasticdump.js
+++ b/elasticdump.js
@@ -40,6 +40,7 @@ var elasticdump = function(input, output, options){
     InputProto = require(__dirname + "/lib/transports/" + self.inputType)[self.inputType];
     self.input  = (new InputProto(self, self.options.input, self.options['input-index']));
   }else if(self.options.inputTransport){
+    self.inputType = 'inputTransport';
     InputProto = require(self.options.inputTransport);
     var inputProtoKeys = Object.keys(InputProto);
     self.input = (new InputProto[inputProtoKeys[0]](self, self.options.input, self.options['input-index']));
@@ -59,6 +60,7 @@ var elasticdump = function(input, output, options){
     OutputProto = require(__dirname + "/lib/transports/" + self.outputType)[self.outputType];
     self.output = (new OutputProto(self, self.options.output, self.options['output-index']));
   }else if(self.options.outputTransport){
+    self.outputType = 'outputTransport';
     OutputProto = require(self.options.outputTransport);
     var outputProtoKeys = Object.keys(OutputProto);
     self.output = (new OutputProto[outputProtoKeys[0]](self, self.options.output, self.options['output-index']));


### PR DESCRIPTION
Fixes 'undefined' being printed out in logs.

<img width="611" alt="screen shot 2015-12-22 at 16 54 50" src="https://cloud.githubusercontent.com/assets/432425/11960909/ec61f1cc-a8cc-11e5-9ce4-86257fbc5928.png">
