### PR TITLE
Add --bulk-mode and --input-file-buffer-size options

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -16,6 +16,7 @@ var defaults = {
   maxSockets:      null,
   input:           null,
   'input-index':   null,
+  'input-file-buffer-size': null,
   output:          null,
   'output-index':  null,
   inputTransport:  null,

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -27,6 +27,7 @@ var defaults = {
   'ignore-errors': false,
   scrollTime:      '10m',
   'bulk-use-output-index-name': false,
+  'bulk-mode':     'index',
   timeout:         null,
   skip:            null,
   toLog:           null,

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -2,35 +2,35 @@ elasticdump: Import and export tools for elasticsearch
 
 Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 
---input                       
+--input
                     Source location (required)
 --input-index
                     Source index and type
                     (default: all, example: index/type)
---output                      
+--output
                     Destination location (required)
 --output-index
                     Destination index and type
                     (default: all, example: index/type)
 --limit
-                    How many objects to move in bulk per operation 
+                    How many objects to move in bulk per operation
                     (default: 100)
 --debug
-                    Display the elasticsearch commands being used 
+                    Display the elasticsearch commands being used
                     (default: false)
 --type
-                    What are we exporting? 
+                    What are we exporting?
                     (default: data, options: [data, mapping])
 --delete
-                    Delete documents one-by-one from the input as they are 
+                    Delete documents one-by-one from the input as they are
                     moved.  Will not delete the source index
                     (default: false)
 --searchBody
-                    Preform a partial extract based on search results 
-                    (when ES is the input, 
+                    Preform a partial extract based on search results
+                    (when ES is the input,
                       default: '{"query": { "match_all": {} } }')
 --sourceOnly
-                    Output only the json contained within the document _source 
+                    Output only the json contained within the document _source
                       Normal: {"_index":"","_type":"","_id":"", "_source":{SOURCE}}
                       sourceOnly: {SOURCE}
                       default: false
@@ -39,61 +39,67 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                       Note: Most useful in conjunction with sourceOnly to create a file of a single JSON entry per line
                       default: false
 --all
-                    Load/store documents from ALL indexes 
+                    Load/store documents from ALL indexes
                     (default: false)
 --bulk
-                    Leverage elasticsearch Bulk API when writing documents 
+                    Leverage elasticsearch Bulk API when writing documents
                     (default: false)
 --ignore-errors
-                    Will continue the read/write loop on write error 
+                    Will continue the read/write loop on write error
                     (default: false)
 --scrollTime
-                    Time the nodes will hold the requested search in order. 
+                    Time the nodes will hold the requested search in order.
                     (default: 10m)
 --maxSockets
-                    How many simultaneous HTTP requests can we process make? 
-                    (default: 
-                      5 [node <= v0.10.x] / 
+                    How many simultaneous HTTP requests can we process make?
+                    (default:
+                      5 [node <= v0.10.x] /
                       Infinity [node >= v0.11.x] )
---bulk-use-output-index-name  
+--bulk-mode
+                    The mode can be index, delete or update.
+                    'index': Add or replace documents on the destination index.
+                    'delete': Delete documents on destination index.
+                    'update': Use 'doc_as_upsert' option with bulk update API to do partial update.
+                    (default: index)
+--bulk-use-output-index-name
                     Force use of destination index name (the actual output URL)
-                    as destination while bulk writing to ES. Allows 
-                    leveraging Bulk API copying data inside the same 
-                    elasticsearch instance. 
+                    as destination while bulk writing to ES. Allows
+                    leveraging Bulk API copying data inside the same
+                    elasticsearch instance.
                     (default: false)
 --timeout
-                    Integer containing the number of milliseconds to wait for 
-                    a request to respond before aborting the request. Passed 
-                    directly to the request library. If used in bulk writing, 
-                    it will result in the entire batch not being written. 
+                    Integer containing the number of milliseconds to wait for
+                    a request to respond before aborting the request. Passed
+                    directly to the request library. If used in bulk writing,
+                    it will result in the entire batch not being written.
                     Mostly used when you don't care too much if you lose some
                     data when importing but rather have speed.
 --skip
-                    Integer containing the number of rows you wish to skip 
-                    ahead from the input transport.  When importing a large 
-                    index, things can go wrong, be it connectivity, crashes, 
-                    someone forgetting to `screen`, etc.  This allows you 
-                    to start the dump again from the last known line written 
-                    (as logged by the `offset` in the output).  Please be 
-                    advised that since no sorting is specified when the 
-                    dump is initially created, there's no real way to 
-                    guarantee that the skipped rows have already been 
-                    written/parsed.  This is more of an option for when 
-                    you want to get most data as possible in the index 
-                    without concern for losing some rows in the process, 
+                    Integer containing the number of rows you wish to skip
+                    ahead from the input transport.  When importing a large
+                    index, things can go wrong, be it connectivity, crashes,
+                    someone forgetting to `screen`, etc.  This allows you
+                    to start the dump again from the last known line written
+                    (as logged by the `offset` in the output).  Please be
+                    advised that since no sorting is specified when the
+                    dump is initially created, there's no real way to
+                    guarantee that the skipped rows have already been
+                    written/parsed.  This is more of an option for when
+                    you want to get most data as possible in the index
+                    without concern for losing some rows in the process,
                     gsimilar to the `timeout` option.
 --inputTransport
                     Provide a custom js file to us as the input transport
 --outputTransport
                     Provide a custom js file to us as the output transport
 --toLog
-                    When using a custom outputTransport, should log lines 
-                    be appended to the output stream? 
+                    When using a custom outputTransport, should log lines
+                    be appended to the output stream?
                     (default: true, except for `$`)
 --help
                     This page
 
-Examples: 
+Examples:
 
 # Copy an index from production to staging with mappings:
 elasticdump \

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -55,6 +55,10 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     (default:
                       5 [node <= v0.10.x] /
                       Infinity [node >= v0.11.x] )
+--input-file-buffer-size
+                    Set the buffer size for file type input. If there are large size documents, increase
+                    the buffer size to get better performance.
+                    (default: null)
 --bulk-mode
                     The mode can be index, delete or update.
                     'index': Add or replace documents on the destination index.

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -275,25 +275,32 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback){
             timeout: self.parent.options.timeout,
         };
         var useOutputIndexName = self.parent.options['bulk-use-output-index-name'] === true;
+        var bulkMode = self.parent.options['bulk-mode'] || 'index';
         data.forEach(function(elem, index, theArray) {
-            var val = "{ \"index\" : { ";
+            var actionMeta = {};
+            var meta = actionMeta[bulkMode] = {};
             if (!useOutputIndexName) { // Not setting _index should use the one defined in URL.
-              val += "\"_index\" : \"" + elem._index + "\", ";
+                meta._index = elem._index;
             }
-            val += "\"_type\" : \""  + elem._type  + "\", ";
-            val += "\"_id\" : \""    + elem._id    + "\"";
+            meta._type = elem._type;
+            meta._id = elem._id;
             if (elem.fields) {
-              extraFields.forEach(function(field) {
-                if (elem.fields[field]) {
-                  val += ', "' + field + '" : "' + elem.fields[field] + '"';
-                }
-                if (elem.fields['_'+field]) {
-                  val += ', "' + field + '" : "' + elem.fields['_'+field] + '"';
-                }
-              });
+                extraFields.forEach(function(field) {
+                    if (elem.fields[field]) {
+                        meta[field] = elem.fields[field];
+                    }
+                    if (elem.fields['_' + field]) {
+                        meta[field] = elem.fields['_' + field];
+                    }
+                });
             }
-            val += " } }\n";
-            val += JSON.stringify(elem._source) + "\n";
+            var val = JSON.stringify(actionMeta) + "\n";
+            if (bulkMode !== 'delete') {
+                var actionData = (bulkMode === 'update')
+                    ? { doc: elem._source, doc_as_upsert: true }
+                    : elem._source;
+                val += JSON.stringify(actionData) + "\n";
+            }
             theArray[index] = val;
         });
         payload.body = data.join("");
@@ -306,7 +313,7 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback){
                         writes = data.length;
                     }else{
                         r.items.forEach(function(item){
-                            if(item.index.status < 400){
+                            if(item[bulkMode].status < 400){
                                 writes++;
                             }
                         });

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -15,12 +15,13 @@ var file = function(parent, file){
 // return (error, arr) where arr is an array of objects
 file.prototype.get = function(limit, offset, callback){
   var self = this;
-  
+  var bufferSize = self.parent.options['input-file-buffer-size'];
+
   if(!self.reader){
     lineReader.open(self.file, function(reader){
       self.reader  = reader;
       self.getLines(limit, offset, callback);
-    });
+    }, null, null, bufferSize);
   }else{
     self.getLines(limit, offset, callback);
   }
@@ -30,7 +31,7 @@ file.prototype.getLines = function(limit, offset, callback, data){
   var self = this;
 
   if(!data){ data = []; }
-  
+
   if(data.length >= limit){
     callback(null, data);
   }else if( self.reader.hasNextLine() ){
@@ -38,7 +39,7 @@ file.prototype.getLines = function(limit, offset, callback, data){
       if(line[0] == ','){ line = line.substring(1); }
       line = line.trim();
 
-      if(line.length > 1){ 
+      if(line.length > 1){
         // are we skipping?
         if(!self.parent.options.skip || (self.parent.options.skip !== null && self.getLineCounter >= self.parent.options.skip)) {
           // no, lets push the data
@@ -56,7 +57,7 @@ file.prototype.getLines = function(limit, offset, callback, data){
 };
 
 // accept arr, callback where arr is an array of objects
-// return (error, writes) 
+// return (error, writes)
 file.prototype.set = function(data, limit, offset, callback){
   var self         = this;
   var error        = null;
@@ -84,7 +85,7 @@ file.prototype.set = function(data, limit, offset, callback){
       try { self.writeStream.end(); } catch(e) { };
       callback(error, data.length);
     }, 200);
-  }else{   
+  }else{
     var ok = true;
     data.forEach(function(elem){
       // Omit comma if we are outputting jsonLines
@@ -111,7 +112,7 @@ file.prototype.set = function(data, limit, offset, callback){
       });
     }
   }
-  
+
 };
 
 exports.file = file;


### PR DESCRIPTION
Add `--bulk-mode` option which allows bulk partial update and bulk delete.

While input file contains large documents (several MB per doc), the loading speed will become extremely slow, this issue can be solved by increasing the buffer size of `line-reader` module, and the `--input-file-buffer-size` does the trick.