### PR TITLE
Cleaning up the apt cache and removing /var/lib/apt/lists to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:trusty
 MAINTAINER arthur@caranta.com
 
 RUN apt-get update -y
-RUN apt-get install -y npm
+RUN apt-get install -y npm && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN npm install elasticdump -g
 #Fix nodejs path (thx debian/ubuntu package ...)
 RUN ln -s "$(which nodejs)" /usr/bin/node


### PR DESCRIPTION
Cleaning up the apt cache and removing /var/lib/apt/lists to reduce image size

Based on [Best practices for writing Dockerfiles](https://docs.docker.com/engine/articles/dockerfile_best-practices/)