### PR TITLE
Remove duplicate --input-file-buffer-size command

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,6 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     'delete': Delete documents on destination index.
                     'update': Use 'doc_as_upsert' option with bulk update API to do partial update.
                     (default: index)
---input-file-buffer-size
-                    Set the buffer size for file type input. If there are large size documents, increase
-                    the buffer size to get better performance.
-                    (default: null)
 --bulk-use-output-index-name
                     Force use of destination index name (the actual output URL)
                     as destination while bulk writing to ES. Allows


### PR DESCRIPTION
I really like this option, but not enough to have it twice