### PR TITLE
Moving Docker image to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,8 @@
-FROM ubuntu:trusty
+FROM alpine:3.3
 MAINTAINER evan@evantahler.com
 
-RUN apt-get update -y && \
-    apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - && \
-    apt-get install -y nodejs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --update nodejs
 
 RUN npm install elasticdump -g
 
-#And finally use elasticdump as the entrypoint
 ENTRYPOINT ["/usr/lib/node_modules/elasticdump/bin/elasticdump"]


### PR DESCRIPTION
Move base image to Alpine Linux to reduce image size (only 33.56 MB instead of ~350 MB)