### PR TITLE
Delete symlink, fix path for elasticdump bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,7 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-#Fix nodejs path (thx debian/ubuntu package ...)
-RUN ln -s "$(which nodejs)" /usr/bin/node
-
 RUN npm install elasticdump -g
 
 #And finally use elasticdump as the entrypoint
-ENTRYPOINT ["/usr/local/bin/elasticdump"]
+ENTRYPOINT ["/usr/lib/node_modules/elasticdump/bin/elasticdump"]


### PR DESCRIPTION
Delete symlink for nodejs, existing good one.
Fix path for elasticdump bin in ENTRYPOINT command.