### PR TITLE
Fix bug in file.js that errors if directory doesn't exist

### DIFF
--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -84,6 +84,7 @@ file.prototype.completeBatch = function(error, callback){
 // accept arr, callback where arr is an array of objects
 // return (error, writes)
 file.prototype.set = function(data, limit, offset, callback){
+<<<<<<< Updated upstream
   var self = this;
   var error = null;
 
@@ -99,6 +100,21 @@ file.prototype.set = function(data, limit, offset, callback){
       }else{
         self.stream = fs.createWriteStream(self.file);
       }
+=======
+  var self         = this;
+  var error        = null;
+
+  if(!self.writeStream){
+    // create the file
+    try{
+      fs.unlinkSync(self.file);
+      fs.mkdirSync(self.file);
+    }catch(e){ }
+    self.writeStream = fs.createWriteStream(self.file, { flags : 'w' });
+    // jsonLines means one JSON has per line.  Omit bracket if jsonLines
+    if(self.parent.options.jsonLines === false) {
+      self.writeStream.write("[\r\n");
+>>>>>>> Stashed changes
     }
   }
 


### PR DESCRIPTION
Duplicate line of code replaced with mkdir

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/taskrabbit/elasticsearch-dump/173)
<!-- Reviewable:end -->
