### PR TITLE
Escape index mapping path

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -159,7 +159,7 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback){
                 for(var key in mappings){
                     var mapping  =  {};
                     mapping[key] = mappings[key];
-                    var url = self.base.url + '/' + key + '/_mapping';
+                    var url = self.base.url + '/' + encodeURIComponent(key) + '/_mapping';
                     started++;
                     count++;
 


### PR DESCRIPTION
Fix error when mapping name include special character

```json
{
  "product_production": {
    "mappings": {
      "user/admin": {
        "properties": {
          "..." 
        },
      }
    }
 }
}
```

Mapping above will produce following error during restore
`Error: failed to parse json (message: "Unexpected token N") - source: "No handler found for uri [/product_production/admin/user/_mapping] and method [PUT]"`

Expected uri should `/product_production/admin%2Fuser/_mapping` for previous mapping to work correctly.