### PR TITLE
Fixes issue #158 deprecated scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 ## Elasticsearch's scan and scroll method
 Elasticsearch provides a [scan and scroll](https://www.elastic.co/guide/en/elasticsearch/guide/1.x/scan-scroll.html) API to fetch all documents of an index starting form (and keeping) a consistent snapshot in time, which we use under the hood.  This method is safe to use for large exporrts since it will maintain the result set in cache for the given period of time.
 
+The actual use of `scan` is deprecated in Elasticsearch 5.0 and is now replaced by the backward compatible `sort: ['doc']`.  See https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_literal_search_type_scan_literal_removed
+
 NOTE: only works for `--output`
 
 ## MultiElasticDump

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -12,8 +12,10 @@ var elasticsearch = function(parent, url, index) {
 // accept callback
 // return (error, arr) where arr is an array of objects
 elasticsearch.prototype.get = function(limit, offset, callback) {
+
   var self = this;
   var type = self.parent.options.type;
+  console.log('--11111-elasticsearch.prototype.get');
   if (type === 'data') {
     self.getData(limit, offset, callback);
   } else if (type === 'mapping') {
@@ -23,6 +25,7 @@ elasticsearch.prototype.get = function(limit, offset, callback) {
   } else {
     callback(new Error('unknown type option'), null);
   }
+  console.log('--11111-elasticsearch.prototype.get returned');
 };
 
 elasticsearch.prototype.getMapping = function(limit, offset, callback) {
@@ -63,15 +66,19 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
   var searchRequest, self, uri;
   self = this;
   var searchBody = self.parent.options.searchBody;
+  console.log('  --22222-elasticsearch.prototype.getData');
 
   if (offset >= self.totalSearchResults && self.totalSearchResults !== 0) {
+    console.log('  --22222-elasticsearch.prototype.getData callback(null, []);');
     callback(null, []);
     return;
   }
 
   if (self.lastScrollId !== null) {
+    console.log('  --22222-elasticsearch.prototype.getData self.lastScrollId !== null');
     scrollResultSet(self, callback);
   } else {
+    console.log('  --22222-elasticsearch.prototype.getData self.lastScrollId === null');
     self.numberOfShards(self.base, function(err, numberOfShards) {
       var shardedLimit = Math.ceil(limit / numberOfShards);
 
@@ -92,6 +99,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
         "body": JSON.stringify(searchBody)
       };
 
+      console.log('  --22222-elasticsearch.prototype.getData searchRequest=' + JSON.stringify(searchRequest));
       request.get(searchRequest, function requestResonse(err, response) {
         if (err) {
           callback(err, []);
@@ -101,17 +109,23 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
           callback(err, []);
           return;
         }
+        // console.log('  --22222-elasticsearch.prototype.getData response.body=\n' + JSON.stringify(response.body));
+        console.log('  --22222-elasticsearch.prototype.getData response.body.length=' + JSON.stringify(response.body).length);
 
         var body = jsonParser.parse(response.body);
         self.lastScrollId = body._scroll_id;
         if (self.lastScrollId === undefined) {
+          console.log('ERROR *************************************');
           err = new Error("Unable to obtain scrollId; This tends to indicate an error with your index(es)");
           callback(err, []);
           return;
         }
         self.totalSearchResults = body.hits.total;
+        console.log('  --22222-elasticsearch.prototype.getData self.totalSearchResults = ' + self.totalSearchResults);
 
         scrollResultSet(self, callback);
+        console.log('  --22222-elasticsearch.prototype.getData returned from scrollResultSet');
+
       });
     });
   }
@@ -389,12 +403,14 @@ function scrollResultSet(that, callback) {
     "method": "POST",
     "body": self.lastScrollId
   };
+  console.log('    ---33333-scrollResultSet scrollRequest = ' + JSON.stringify(scrollRequest));
 
   request.get(scrollRequest, function requestResonse(err, response) {
     if (err) {
       callback(err, []);
       return;
     }
+    console.log('    ---33333-scrollResultSet response.body = ' + JSON.stringify(response.body));
 
     if (err === null && response.statusCode != 200) {
       err = new Error(response.body);
@@ -412,6 +428,9 @@ function scrollResultSet(that, callback) {
 
     self.lastScrollId = body._scroll_id;
     var hits = body.hits.hits;
+
+    console.log('    ---33333-scrollResultSet body.hits.hits.length = ' + body.hits.hits.length);
+    console.log('    ---33333-scrollResultSet body.hits.total = ' + body.hits.total);
 
     if (self.parent.options.delete === true && hits.length > 0) {
       var started = 0;
@@ -452,6 +471,7 @@ function scrollResultSet(that, callback) {
         }
       } else {
         // not skipping or done skipping
+        console.log('    ---33333-scrollResultSet not skipping or done skipping ');
         callback(err, hits);
       }
     }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -77,13 +77,16 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
 
       uri = self.base.url +
         "/" +
-        "_search?search_type=scan&scroll=" +
+        "_search?scroll=" +
         self.parent.options.scrollTime +
         "&size=" + shardedLimit;
 
       searchBody.size = shardedLimit;
 
       searchRequest = {
+        "sort": [
+          "_doc"
+	    ],
         "uri": uri,
         "method": "GET",
         "body": JSON.stringify(searchBody)
@@ -114,8 +117,9 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
   }
 };
 
-// to respect the --limit param, we need to set the scan/sroll limit = limit/#Shards
-// http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
+// to respect the --limit param, we need to set the scroll limit = limit/#Shards
+// http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html (older versions)
+// https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_literal_search_type_scan_literal_removed
 elasticsearch.prototype.numberOfShards = function(base, callback) {
   request.get(base.url + "/_settings", function(err, response) {
     if (err) {


### PR DESCRIPTION
Fixes issue #158 "Scan deprecation warning".  Tested on Elasticsearch master (5.0) and 2.3.

This worked on both Elasticsearch versions for a logstash index, but both failed to get any documents for my .kibana index.  But I think this is a different issue.  I'll investigate that.

```
$ time /c/git/elasticsearch-dump/bin/elasticdump --input=http://localhost:9200/logstash-0 --output=logstash.json  --type=data --bulk-use-output-index-name
Thu, 14 Apr 2016 19:21:53 GMT | starting dump
Thu, 14 Apr 2016 19:21:53 GMT | got 100 objects from source elasticsearch (offset: 0)
Thu, 14 Apr 2016 19:21:53 GMT | sent 100 objects to destination file, wrote 100
Thu, 14 Apr 2016 19:21:53 GMT | got 100 objects from source elasticsearch (offset: 100)
Thu, 14 Apr 2016 19:21:53 GMT | sent 100 objects to destination file, wrote 100
Thu, 14 Apr 2016 19:21:53 GMT | got 100 objects from source elasticsearch (offset: 200)
Thu, 14 Apr 2016 19:21:53 GMT | sent 100 objects to destination file, wrote 100
```         