### PR TITLE
Typo error on comment "interate"

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -207,7 +207,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
     var count = 0;
     for (var index in data) {
       var settings = data[index]['settings'];
-      for (var key in settings) { // interate through settings
+      for (var key in settings) { // iterate through settings
         var setting = {};
         setting[key] = settings[key];
         var url = self.base.url + '/_settings';


### PR DESCRIPTION
Typo error on comment "interate" instead of "iterate" 
On elasticsearch.prototype.setAnalyzer