### PR TITLE
Add type=settings options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 notifications:
   email:
-    - evantahler@gmail.com
+    - bloublou2014@gmail.com
 language: node_js
 node_js:
   - "iojs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 notifications:
   email:
-    - bloublou2014@gmail.com
+    - evantahler@gmail.com
 language: node_js
 node_js:
   - "iojs"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Stdio:
 You can then do things like:
 
 ```bash
-# Copy an index from production to staging with analyzer and mapping:
+# Copy an index from production to staging with settings, analyzer and mapping:
+elasticdump \
+  --input=http://production.es.com:9200/my_index \
+  --output=http://staging.es.com:9200/my_index \
+  --type=settings
 elasticdump \
   --input=http://production.es.com:9200/my_index \
   --output=http://staging.es.com:9200/my_index \
@@ -183,7 +187,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     (default: false)
 --type
                     What are we exporting?
-                    (default: data, options: [data, mapping])
+                    (default: data, options: [settings, analyzer, data, mapping])
 --delete
                     Delete documents one-by-one from the input as they are
                     moved.  Will not delete the source index

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -21,7 +21,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     (default: false)
 --type
                     What are we exporting?
-                    (default: data, options: [data, mapping])
+                    (default: data, options: [settings, analyzer, data, mapping])
 --delete
                     Delete documents one-by-one from the input as they are
                     moved.  Will not delete the source index

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -18,7 +18,7 @@ elasticsearch.prototype.get = function(limit, offset, callback) {
     self.getData(limit, offset, callback);
   } else if (type === 'mapping') {
     self.getMapping(limit, offset, callback);
-  } else if (type === 'analyzer') {
+  } else if (type === 'analyzer' || type === 'settings') {
     self.getSettings(limit, offset, callback);
   } else {
     callback(new Error('unknown type option'), null);
@@ -143,6 +143,8 @@ elasticsearch.prototype.set = function(data, limit, offset, callback) {
     self.setMapping(data, limit, offset, callback);
   } else if (type === 'analyzer') {
     self.setAnalyzer(data, limit, offset, callback);
+  } else if (type === 'settings') {
+    self.setSettings(data, limit, offset, callback);
   } else {
     callback(new Error('unknown type option'), null);
   }
@@ -192,6 +194,67 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
         }
       }
     });
+  }
+};
+
+elasticsearch.prototype.setSettings = function(data, limit, offset, callback) {
+  var self = this;
+  var started = 0;
+  var count = 0;
+
+  var updateSettings = function(err, response) {
+    // check if data contains a number of shards - shards can't be modified after index creation
+    try {
+        data = jsonParser.parse(data[0]);
+    } catch (e) {
+        return callback(e);
+    }
+
+    for (var index in data) {
+      var settings = data[index]['settings'];
+
+      for (var key in settings) { // iterate through settings
+        var setting = {};
+        setting[key] = settings[key];
+        var url = self.base.url;
+        started++;
+        count++;
+        var payload = {
+            url: url,
+            timeout: self.parent.options.timeout
+        };
+        // check if index exists
+        request.head(payload, function(err, response) { // upload the settings
+          started--;
+          if (!err) {
+            if (response.statusCode != 404){
+                callback("Index " + index + " exists, cannot put settings", count);
+            }
+          } else {
+              callback(err, count);
+          }
+
+          if (started === 0) {
+            payload.body = JSON.stringify(setting);
+            self.haveSetSettings = true;
+            request.put(payload, function(err, response) {
+              if (!err) {
+                var bodyError = jsonParser.parse(response.body).error;
+                if (bodyError) {
+                  err = bodyError;
+                }
+              }
+              callback(err, count);
+            });
+          }
+        });
+      }
+    }
+  };
+  if (self.haveSetSettings === true) {
+    callback(null, 0);
+  } else {
+    updateSettings();
   }
 };
 
@@ -269,7 +332,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
         });
       }
     }
-  }
+  };
   if (self.haveSetAnalyzer === true) {
     callback(null, 0);
   } else {


### PR DESCRIPTION
Add type=settings to export/import whole index settings
Since some options like number_of_shards cannot be set if output index exists, an error is throw if output index exists.

This functionality is useful during backup/restore index. Currently elasticdump create a new index without saved index settings, leading to unwanted shards or replicas default setting.

Important : this is my first functionality commit, if a process has to be fulfilled or function is not appropriate, fell free to reject this pull request.