### PR TITLE
Will fix scan/scroll and parent/child issues with ES v2.x and onward. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ branches:
 # services:
 #   - elasticsearch
 
-env:
-  - "ES_VERSION=2.3.1"
-  - "ES_VERSION=1.7.4"
+# env:
+#   - "ES_VERSION=2.3.1"
+#   - "ES_VERSION=1.7.4"
 
 before_install:
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart
+  # - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.3.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.3.deb && sudo service elasticsearch restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,7 @@ branches:
 
 before_install:
   # - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.3.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.3.deb && sudo service elasticsearch restart
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.3.deb
+  - sudo dpkg -i --force-confnew elasticsearch-1.7.3.deb
+  - sudo service elasticsearch restart
+  - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 notifications:
   email:
@@ -11,6 +11,14 @@ node_js:
 branches:
   only:
     - master
-services:
-  - redis-server
-  - elasticsearch
+
+# We'll manually install versions of ES ourselves
+# services:
+#   - elasticsearch
+
+env:
+  - "ES_VERSION=2.3.1"
+  - "ES_VERSION=1.7.4"
+
+before_install:
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,12 @@ branches:
 # services:
 #   - elasticsearch
 
-# env:
-#   - "ES_VERSION=2.3.1"
-#   - "ES_VERSION=1.7.4"
+env:
+  - "ES_VERSION=2.3.1"
+  - "ES_VERSION=1.7.4"
 
 before_install:
-  # - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb && sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb && sudo service elasticsearch restart
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.3.deb
-  - sudo dpkg -i --force-confnew elasticsearch-1.7.3.deb
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb
+  - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb
   - sudo service elasticsearch restart
-  - sleep 15
+  - sleep 15 # ES needs some time to start :/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ env:
   - "ES_VERSION=1.7.4"
 
 before_install:
-  # - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb
-  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb
+  ## ES has different download locations for each version, so we'll download them both and then just use the one we want
+  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.4.deb
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.1/elasticsearch-2.3.1.deb
+  ## Now, use the ENV to choose the version
   - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb
   - sudo service elasticsearch restart
-  - sleep 15 # ES needs some time to start :/
+  # ES needs some time to start
+  - sleep 15

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ env:
   - "ES_VERSION=1.7.4"
 
 before_install:
-  - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb
+  # - curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-$ES_VERSION.deb
+  - curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.deb
   - sudo dpkg -i --force-confnew elasticsearch-$ES_VERSION.deb
   - sudo service elasticsearch restart
   - sleep 15 # ES needs some time to start :/

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     This page
 ```
 
-## Elasticsearch's scan and scroll method
-Elasticsearch provides a [scan and scroll](https://www.elastic.co/guide/en/elasticsearch/guide/1.x/scan-scroll.html) API to fetch all documents of an index starting form (and keeping) a consistent snapshot in time, which we use under the hood.  This method is safe to use for large exporrts since it will maintain the result set in cache for the given period of time.
+## Elasticsearch's Scroll API
+Elasticsearch provides a [scroll](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html) API to fetch all documents of an index starting form (and keeping) a consistent snapshot in time, which we use under the hood.  This method is safe to use for large exports since it will maintain the result set in cache for the given period of time.
 
 NOTE: only works for `--output`
 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -303,9 +303,10 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback) {
       thisUrl += elem._index + "/";
     }
     thisUrl += encodeURIComponent(elem._type) + "/" + encodeURIComponent(elem._id);
-    if (elem.fields) {
-      var and = "?";
-      extraFields.forEach(function(field) {
+
+    var and = "?";
+    extraFields.forEach(function(field) {
+      if(elem.fields){
         if (elem.fields[field]) {
           thisUrl += and + field + "=" + encodeURIComponent(elem.fields[field]);
           and = "&";
@@ -314,8 +315,18 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback) {
           thisUrl += and + field + "=" + encodeURIComponent(elem.fields['_' + field]);
           and = "&";
         }
-      });
-    }
+      }else{
+        if (elem[field]) {
+          thisUrl += and + field + "=" + encodeURIComponent(elem[field]);
+          and = "&";
+        }
+        if (elem['_' + field]) {
+          thisUrl += and + field + "=" + encodeURIComponent(elem['_' + field]);
+          and = "&";
+        }
+      }
+    });
+
     var payload = {
       url: thisUrl,
       body: JSON.stringify(elem._source),

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -168,16 +168,26 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
       var count = 0;
       for (var index in data) {
         var mappings = data[index]['mappings'];
-        for (var key in mappings) {
+        var sortedMappings = [];
+
+        // TODO: it seems we need to set the mappings for children with parents first?
+        for(var key in mappings){
+          if(mappings[key]._parent){
+            sortedMappings = [{key: key, data: mappings[key]}].concat(sortedMappings);
+          }else{
+            sortedMappings.push({key: key, data: mappings[key]});
+          }
+        }
+
+        sortedMappings.forEach(function(set){
           var mapping = {};
-          mapping[key] = mappings[key];
-          var url = self.base.url + '/' + encodeURIComponent(key) + '/_mapping';
+          var url = self.base.url + '/' + encodeURIComponent(set.key) + '/_mapping';
           started++;
           count++;
 
           var payload = {
             url: url,
-            body: JSON.stringify(mapping),
+            body: JSON.stringify(set.data),
             timeout: self.parent.options.timeout,
           };
 
@@ -194,7 +204,7 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
               callback(err, count);
             }
           });
-        }
+        });
       }
     });
   }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -75,6 +75,9 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
     self.numberOfShards(self.base, function(err, numberOfShards) {
       var shardedLimit = Math.ceil(limit / numberOfShards);
 
+      // previously we used the scan/scroll method, but now we need to change the sort
+      // https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_literal_search_type_scan_literal_removed
+
       uri = self.base.url +
         "/" +
         "_search?search_type=scan&scroll=" +
@@ -86,6 +89,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
       searchRequest = {
         "uri": uri,
         "method": "GET",
+        "sort": [ "_doc" ],
         "body": JSON.stringify(searchBody)
       };
 
@@ -101,6 +105,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
 
         var body = jsonParser.parse(response.body);
         self.lastScrollId = body._scroll_id;
+
         if (self.lastScrollId === undefined) {
           err = new Error("Unable to obtain scrollId; This tends to indicate an error with your index(es)");
           callback(err, []);
@@ -108,7 +113,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
         }
         self.totalSearchResults = body.hits.total;
 
-        scrollResultSet(self, callback);
+        scrollResultSet(self, callback, body.hits.hits);
       });
     });
   }
@@ -376,9 +381,13 @@ exports.elasticsearch = elasticsearch;
  * @param that
  * @param callback
  */
-function scrollResultSet(that, callback) {
+function scrollResultSet(that, callback, loadedHits){
   var self = that;
   var body;
+
+  if(loadedHits && loadedHits.length > 0){
+    return callback(null, loadedHits);
+  }
 
   var scrollRequest = {
     "uri": self.base.host + "/_search" + "/scroll?scroll=" + self.parent.options.scrollTime,

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -85,7 +85,7 @@ describe('parent child', function(){
     });
   });
 
-  after(function(done){ clear(done); });
+  // after(function(done){ clear(done); });
 
   it('did the setup properly and parents + children are loaded', function(done){
     var url = baseUrl + "/source_index/_search";
@@ -232,7 +232,7 @@ describe('parent child', function(){
 
       mappingDumper.dump(function(){
       dataDumper.dump(function(){
-        done();
+        setTimeout(done, 500);
       });
       });
     });
@@ -261,7 +261,7 @@ describe('parent child', function(){
         if(d._type === 'person'){
           var parent;
           if(d._parent){ var parent = d._parent}  // ES 2.x
-          if(d.fields._parent){ var parent = d.fields._parent}  // ES 1.x
+          if(d.fields && d.fields._parent){ var parent = d.fields._parent}  // ES 1.x
           should.exist( parent );
           dumpedPeople.push(d);
         }
@@ -279,6 +279,8 @@ describe('parent child', function(){
 
     describe('can restore from a dumpfile', function(){
       before(function(done){
+        this.timeout(1000 * 10);
+
         var mappingOptions = {
           limit:  100,
           offset: 0,
@@ -307,7 +309,7 @@ describe('parent child', function(){
 
         mappingDumper.dump(function(){
         dataDumper.dump(function(){
-          done();
+          setTimeout(done, 500);
         });
         });
       });

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -85,7 +85,7 @@ describe('parent child', function(){
     });
   });
 
-  // after(function(done){ clear(done); });
+  after(function(done){ clear(done); });
 
   it('did the setup properly and parents + children are loaded', function(done){
     var url = baseUrl + "/source_index/_search";
@@ -259,7 +259,10 @@ describe('parent child', function(){
       var dumpedCties = [];
       dataLines.forEach(function(d){
         if(d._type === 'person'){
-          should.exist( d._parent );
+          var parent;
+          if(d._parent){ var parent = d._parent}  // ES 2.x
+          if(d.fields._parent){ var parent = d.fields._parent}  // ES 1.x
+          should.exist( parent );
           dumpedPeople.push(d);
         }
         if(d._type === 'city'){


### PR DESCRIPTION
- move from scan/scroll when reading ES to using scan with a doc sort of `_id`
  -  while this is the recommended procedure for ES v2.x onward, this is technically slower for ES v1.x, but is backwards compatible
  - we now handle when the getting of a scrollId returns hits (ES v2.x)
- handle new parent/child mapping data types in ES v2.x
  - support parent/child link keys in both of the ways that ES v1.x and v2.x report parent child mappings.
  - update the crazy parent/child test to one that makes a lot more sense
- Run test suite (in travis.ci) against multiple versions of Elasticsearch 