### PR TITLE
fix offset; remove skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     directly to the request library. Mostly used when you don't
                     care too much if you lose some data when importing
                     but rather have speed.
---skip
+--offset
                     Integer containing the number of rows you wish to skip
                     ahead from the input transport.  When importing a large
                     index, things can go wrong, be it connectivity, crashes,

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -27,7 +27,6 @@ var defaults = {
   'ignore-errors': false,
   scrollTime:      '10m',
   timeout:         null,
-  skip:            null,
   toLog:           null,
 };
 

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -89,7 +89,7 @@ elasticdump.prototype.validateOptions = function(){
   return validationErrors;
 };
 
-elasticdump.prototype.dump = function(callback, continuing, limit, offset, total_writes, remainingSkip){
+elasticdump.prototype.dump = function(callback, continuing, limit, offset, total_writes){
   var self  = this;
 
   if(self.validationErrors.length > 0){
@@ -100,17 +100,13 @@ elasticdump.prototype.dump = function(callback, continuing, limit, offset, total
     if(!limit){ limit = self.options.limit;  }
     if(!offset){ offset = self.options.offset; }
     if(!total_writes){ total_writes = 0; }
-    if(remainingSkip === undefined || remainingSkip === null){
-      remainingSkip = 0;
-      if(self.options.skip){ remainingSkip = self.options.skip; }
-    }
 
     if(continuing !== true){
       self.log('starting dump');
 
-      if(self.options.skip){
-        self.log('Warning: skipping ' + self.options.skip + ' rows.');
-        self.log("  * skipping doesn't guarantee that the skipped rows have already been written, please refer to the README.");
+      if(self.options.offset){
+        self.log('Warning: offseting ' + self.options.offset + ' rows.');
+        self.log("  * Using an offset doesn't guarantee that the offset rows have already been written, please refer to the HELP text.");
       }
     }
 
@@ -134,20 +130,10 @@ elasticdump.prototype.dump = function(callback, continuing, limit, offset, total
               self.log("sent " + data.length + " objects to destination " + self.outputType + ", wrote " + writes);
               offset = offset + data.length;
             }
-
-            if(remainingSkip > 0){
-              if(remainingSkip > limit){
-                offset = offset + limit;
-                remainingSkip = remainingSkip - limit;
-              }else{
-                offset = offset + remainingSkip;
-                remainingSkip = 0;
-              }
-            }
           }
 
-          if((data.length > 0 && toContinue) || (remainingSkip > 0 && toContinue)){
-            self.dump(callback, true, limit, offset, total_writes, remainingSkip);
+          if(data.length > 0 && toContinue){
+            self.dump(callback, true, limit, offset, total_writes);
           }else if(toContinue){
             self.log('Total Writes: ' + total_writes);
             self.log('dump complete');

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -56,7 +56,7 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     directly to the request library. Mostly used when you don't
                     care too much if you lose some data when importing
                     but rather have speed.
---skip
+--offset
                     Integer containing the number of rows you wish to skip
                     ahead from the input transport.  When importing a large
                     index, things can go wrong, be it connectivity, crashes,

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -383,7 +383,7 @@ function scrollResultSet(self, callback, loadedHits){
   if(loadedHits && loadedHits.length > 0){
 
     // are we skipping and we have hits?
-    if (self.elementsToSkip > 0 && loadedHits.length > 0) {
+    if (self.elementsToSkip > 0 ) {
       while (loadedHits.length > 0 && self.elementsToSkip > 0) {
         loadedHits.splice(0, 1);
         self.elementsToSkip--;
@@ -477,15 +477,15 @@ function scrollResultSet(self, callback, loadedHits){
 
           if (hits.length > 0) {
             // we have some hits after skipping, lets callback
-            callback(err, hits);
+            return callback(err, hits);
           } else {
             // we skipped, but now we don't have any hits,
             // scroll again for more data if possible
-            scrollResultSet(self, callback);
+            return scrollResultSet(self, callback);
           }
         } else {
           // not skipping or done skipping
-          callback(err, hits);
+          return callback(err, hits);
         }
       }
     });

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -7,7 +7,7 @@ var elasticsearch = function(parent, url, index) {
   this.parent = parent;
   this.lastScrollId = null;
   this.totalSearchResults = 0;
-  this.hasSkipped = 0;
+  this.elementsToSkip = 0;
 };
 // accept callback
 // return (error, arr) where arr is an array of objects
@@ -72,69 +72,50 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
   if (self.lastScrollId !== null) {
     scrollResultSet(self, callback);
   } else {
-    self.numberOfShards(self.base, function(err, numberOfShards) {
-      var shardedLimit = Math.ceil(limit / numberOfShards);
+    // previously we used the scan/scroll method, but now we need to change the sort
+    // https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_literal_search_type_scan_literal_removed
 
-      // previously we used the scan/scroll method, but now we need to change the sort
-      // https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking_50_search_changes.html#_literal_search_type_scan_literal_removed
+    // if this is the first time we run, we need to log how many elements we should be skipping
+    if(!self.elementsToSkip){ self.elementsToSkip = offset; }
 
-      uri = self.base.url +
-        "/" +
-        "_search?scroll=" +
-        self.parent.options.scrollTime +
-        "&size=" + shardedLimit;
+    uri = self.base.url +
+      "/" +
+      "_search?scroll=" +
+      self.parent.options.scrollTime +
+      "&from=" + offset;
 
-      searchBody.size = shardedLimit;
+    searchBody.size = limit;
 
-      searchRequest = {
-        "uri": uri,
-        "method": "GET",
-        "sort": [ "_doc" ],
-        "body": JSON.stringify(searchBody)
-      };
+    searchRequest = {
+      "uri": uri,
+      "method": "GET",
+      "sort": [ "_doc" ],
+      "body": JSON.stringify(searchBody)
+    };
 
-      request.get(searchRequest, function requestResonse(err, response) {
-        if (err) {
-          callback(err, []);
-          return;
-        } else if (response.statusCode !== 200) {
-          err = new Error(response.body);
-          callback(err, []);
-          return;
-        }
+    request.get(searchRequest, function requestResonse(err, response) {
+      if (err) {
+        callback(err, []);
+        return;
+      } else if (response.statusCode !== 200) {
+        err = new Error(response.body);
+        callback(err, []);
+        return;
+      }
 
-        var body = jsonParser.parse(response.body);
-        self.lastScrollId = body._scroll_id;
+      var body = jsonParser.parse(response.body);
+      self.lastScrollId = body._scroll_id;
 
-        if (self.lastScrollId === undefined) {
-          err = new Error("Unable to obtain scrollId; This tends to indicate an error with your index(es)");
-          callback(err, []);
-          return;
-        }
-        self.totalSearchResults = body.hits.total;
+      if (self.lastScrollId === undefined) {
+        err = new Error("Unable to obtain scrollId; This tends to indicate an error with your index(es)");
+        callback(err, []);
+        return;
+      }
+      self.totalSearchResults = body.hits.total;
 
-        scrollResultSet(self, callback, body.hits.hits);
-      });
+      scrollResultSet(self, callback, body.hits.hits);
     });
   }
-};
-
-// to respect the --limit param, we need to set the scan/sroll limit = limit/#Shards
-// http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/scan-scroll.html
-elasticsearch.prototype.numberOfShards = function(base, callback) {
-  request.get(base.url + "/_settings", function(err, response) {
-    if (err) {
-      callback(err);
-    } else {
-      try {
-        var body = jsonParser.parse(response.body);
-        var numberOfShards = body[base.index].settings.index.number_of_shards;
-        callback(err, numberOfShards);
-      } catch (e) {
-        callback(err, 1);
-      }
-    }
-  });
 };
 
 // accept arr, callback where arr is an array of objects
@@ -393,30 +374,43 @@ exports.elasticsearch = elasticsearch;
 /**
  * Posts requests to the _search api to fetch the latest
  * scan result with scroll id
- * @param that
+ * @param self
  * @param callback
  */
-function scrollResultSet(that, callback, loadedHits){
-  var self = that;
+function scrollResultSet(self, callback, loadedHits){
   var body;
 
   if(loadedHits && loadedHits.length > 0){
 
-    if (self.parent.options.delete === true) {
-      var started = 0;
-      loadedHits.forEach(function(elem) {
-        started++;
-        self.del(elem, function() {
-          started--;
-          if (started === 0) {
-            self.reindex(function(err) {
-              callback(err, loadedHits);
-            });
-          }
+    // are we skipping and we have hits?
+    if (self.elementsToSkip > 0 && loadedHits.length > 0) {
+      while (loadedHits.length > 0 && self.elementsToSkip > 0) {
+        loadedHits.splice(0, 1);
+        self.elementsToSkip--;
+      }
+    }
+
+    if(loadedHits.length > 0){
+
+      if (self.parent.options.delete === true) {
+        var started = 0;
+        loadedHits.forEach(function(elem) {
+          started++;
+          self.del(elem, function() {
+            started--;
+            if (started === 0) {
+              self.reindex(function(err) {
+                return callback(err, loadedHits);
+              });
+            }
+          });
         });
-      });
+      }else{
+        return callback(null, loadedHits);
+      }
+
     }else{
-      callback(null, loadedHits);
+      return scrollResultSet(self, callback);
     }
 
   }else{
@@ -475,11 +469,10 @@ function scrollResultSet(that, callback, loadedHits){
         }
 
         // are we skipping and we have hits?
-        if (self.parent.options.skip !== null && hits.length > 0 && self.hasSkipped < self.parent.options.skip) {
-          // lets remove hits until we reach the skip number
-          while (hits.length > 0 && self.hasSkipped < self.parent.options.skip) {
-            self.hasSkipped++;
+        if (self.elementsToSkip > 0 && hits.length > 0) {
+          while (hits.length > 0 && self.elementsToSkip > 0) {
             hits.splice(0, 1);
+            self.elementsToSkip--;
           }
 
           if (hits.length > 0) {
@@ -488,7 +481,7 @@ function scrollResultSet(that, callback, loadedHits){
           } else {
             // we skipped, but now we don't have any hits,
             // scroll again for more data if possible
-            scrollResultSet(that, callback);
+            scrollResultSet(self, callback);
           }
         } else {
           // not skipping or done skipping

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -10,11 +10,11 @@ var file = function(parent, file, options, direction) {
   this.lineCounter = 0;
   this.localLineCounter = 0;
   this.stream = null;
+  this.elementsToSkip = 0;
 };
 
 // accept callback
 // return (error, arr) where arr is an array of objects
-// note that "offset" doesn't make any sense here
 file.prototype.get = function(limit, offset, callback) {
   var self = this;
   self.thisGetLimit = limit;
@@ -22,7 +22,7 @@ file.prototype.get = function(limit, offset, callback) {
   self.localLineCounter = 0;
 
   if (self.lineCounter === 0) {
-    self.setupGet();
+    self.setupGet(offset);
   } else {
     self.metaStream.resume();
   }
@@ -32,11 +32,13 @@ file.prototype.get = function(limit, offset, callback) {
   }
 };
 
-file.prototype.setupGet = function() {
+file.prototype.setupGet = function(offset) {
   var self = this;
 
   self.bufferedData = [];
   self.stream = JSONStream.parse();
+
+  if(!self.elementsToSkip){ self.elementsToSkip = offset; }
 
   if (self.file === '$') {
     self.metaStream = process.stdin;
@@ -45,7 +47,9 @@ file.prototype.setupGet = function() {
   }
 
   self.stream.on('data', function(elem) {
-    if (!self.parent.options.skip || (self.parent.options.skip !== null && self.lineCounter >= self.parent.options.skip)) {
+    if(self.elementsToSkip > 0){
+      self.elementsToSkip--;
+    }else{
       self.bufferedData.push(elem);
     }
 
@@ -62,17 +66,22 @@ file.prototype.setupGet = function() {
   });
 
   self.stream.on('end', function() {
-    self.completeBatch(null, self.thisGetCallback);
+    self.completeBatch(null, self.thisGetCallback, true);
   });
 
   self.metaStream.pipe(self.stream);
 };
 
-file.prototype.completeBatch = function(error, callback) {
+file.prototype.completeBatch = function(error, callback, streamEnded) {
   var self = this;
   var data = [];
 
   self.metaStream.pause();
+
+  // if we are skipping, have no data, and there is more to read we should continue on
+  if(!streamEnded && self.elementsToSkip > 0 && self.bufferedData.length === 0){
+    return self.metaStream.resume();
+  }
 
   while (self.bufferedData.length > 0) {
     data.push(self.bufferedData.pop());

--- a/test/test.js
+++ b/test/test.js
@@ -148,7 +148,7 @@ describe("ELASTICDUMP", function(){
       });
     });
 
-    it('can skip', function(done) {
+    it('can provide offset', function(done) {
       this.timeout(testTimeout);
       var options = {
         limit:  100,
@@ -158,7 +158,7 @@ describe("ELASTICDUMP", function(){
         input:  baseUrl + '/source_index',
         output: baseUrl + '/destination_index',
         scrollTime: '10m',
-        skip: 250
+        offset: 250
       };
 
       var dumper = new elasticdump(options.input, options.output, options);
@@ -567,7 +567,7 @@ describe("ELASTICDUMP", function(){
       });
     });
 
-    it('can skip', function(done) {
+    it('can provide offset', function(done) {
       this.timeout(testTimeout);
       var options = {
         limit:  100,
@@ -577,7 +577,7 @@ describe("ELASTICDUMP", function(){
         input: '/tmp/out.json',
         output: baseUrl + '/destination_index',
         scrollTime: '10m',
-        skip: 250
+        offset: 250
       };
 
       var dumper = new elasticdump(options.input, options.output, options);


### PR DESCRIPTION
* fixes https://github.com/taskrabbit/elasticsearch-dump/issues/217

Having both `skip` and `offset` as options was redundant and confusing.  This PR removes `--skip` as an option, and ensures that `--offset` works... because it didn't.