### PR TITLE
Fix the scroll api call

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -412,14 +412,17 @@ function scrollResultSet(self, callback, loadedHits){
     }
 
   }else{
+    bodyData = {}
+    bodyData['scroll'] = self.parent.options.scrollTime
+    bodyData['scroll_id'] = self.lastScrollId
 
     var scrollRequest = {
-      "uri": self.base.host + "/_search" + "/scroll?scroll=" + self.parent.options.scrollTime,
+      "uri": self.base.host + "/_search/scroll",
       "method": "POST",
-      "body": self.lastScrollId
+      "body": JSON.stringify(bodyData),
     };
 
-    request.get(scrollRequest, function requestResonse(err, response) {
+    request.post(scrollRequest, function requestResonse(err, response) {
       if (err) {
         callback(err, []);
         return;


### PR DESCRIPTION
I am doing a migration from elasticsearch v2.3.3 to another elasticsearch v2.3.3 instance, and I stuck upon the problem 'scrollId is missing'. Here are a bit more details: 


>  [debug] | scrollRequest: {\"uri\":\"http://src.mysite.com/_search/scroll?scroll=10m\",\"method\":\"POST\",\"body\":\"cXVlcnlUaGVuRmV0Y2g7NTsxNTA4NTk5OklUYmJ0LXFTUjgtQzhKcFhYdm9wRkE7MTUwODYwMTpJVGJidC1xU1I4LUM4SnBYWHZvcEZBOzE1MDg2MDA6SVRiYnQtcVNSOC1DOEpwWFh2b3BGQTsxNTA4NjAzOklUYmJ0LXFTUjgtQzhKcFhYdm9wRkE7MTUwODYwMjpJVGJidC1xU1I4LUM4SnBYWHZvcEZBOzA7\"}", "Sun, 26 Jun 2016 03:35:03 GMT [debug] | body: \"{\\\"error\\\":{\\\"root_cause\\\":[{\\\"type\\\":\\\"action_request_validation_exception\\\",\\\"reason\\\":\\\"Validation Failed: 1: scrollId is missing;\\\"}],\\\"type\\\":\\\"action_request_validation_exception\\\",\\\"reason\\\":\\\"Validation Failed: 1: scrollId is missing;\\\"}

After I checked the elasticsearch [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html),  seems like the backward compatibility is not preserved. So I made a little adjustment and it worked well. 