### PR TITLE
added support for Amazon Request Signing 4

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -27,6 +27,8 @@ var defaults = {
   scrollTime:      '10m',
   timeout:         null,
   toLog:           null,
+  awsAccessKeyId:    null,
+  awsSecretAccessKey:null,
 };
 
 var options = {};

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -1,0 +1,25 @@
+var aws4 = require('aws4');
+
+aws4signer = function(es_request, awsAccessKeyId, awsSecretAccessKey) {
+    var useAwsCredentials = ((typeof awsAccessKeyId == 'string') && (typeof awsSecretAccessKey == 'string'));
+
+    if (useAwsCredentials) {
+      // get aws required stuff from uri or url
+      var es_url = '';
+      if ((es_request.uri !== undefined) && (es_request.uri !== null)) {
+        es_url = es_request.uri;
+      } else if((es_request.url !== undefined) && (es_request.url !== null)) {
+        es_url = es_request.url;
+      }
+
+      const url = require('url');
+      var urlObj = url.parse(es_url);
+
+      es_request.headers =  { 'host': urlObj.hostname};
+      es_request.path = urlObj.path;
+
+      aws4.sign(es_request, {"accessKeyId": awsAccessKeyId, "secretAccessKey": awsSecretAccessKey});
+    }
+};
+
+module.exports = aws4signer;

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -76,6 +76,12 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     When using a custom outputTransport, should log lines
                     be appended to the output stream?
                     (default: true, except for `$`)
+--awsAccessKeyId
+--awsSecretAccessKey
+                    When using Amazon Elasticsearch Service proteced by
+                    AWS Identity and Access Management (IAM), provide
+                    your Access Key ID and Secret Access Key
+
 --help
                     This page
 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -428,6 +428,7 @@ elasticsearch.prototype.aws4signer = function(es_request) {
     self.parent.emit('debug', 'useAwsCredentials: ' + useAwsCredentials + ', awsAccessKeyId: ' + awsAccessKeyId);
 
     if (useAwsCredentials) {
+      self.parent.emit('debug', 'useAwsCredentials: ' + useAwsCredentials + ', awsAccessKeyId: ' + awsAccessKeyId);
       // get aws required stuff from uri or url
       var es_url = '';
       if ((es_request.uri !== undefined) && (es_request.uri !== null)) {

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -1,6 +1,7 @@
 var request = require('request');
 var jsonParser = require('../jsonparser.js');
 var parseBaseURL = require('../parse-base-url');
+var aws4 = require('aws4');
 
 var elasticsearch = function(parent, url, index) {
   this.base = parseBaseURL(url, index);
@@ -30,8 +31,13 @@ elasticsearch.prototype.getMapping = function(limit, offset, callback) {
   if (self.gotMapping === true) {
     callback(null, []);
   } else {
-    var url = self.base.url + '/_mapping';
-    request.get(url, function(err, response) {
+    var esRequest = {
+      'url': self.base.url + '/_mapping',
+      'method': 'GET'
+    };
+    self.aws4signer(esRequest);
+
+    request.get(esRequest, function(err, response) {
       self.gotMapping = true;
       var payload = [];
       if (!err) {
@@ -47,8 +53,13 @@ elasticsearch.prototype.getSettings = function(limit, offset, callback) {
   if (self.gotSettings === true) {
     callback(null, []);
   } else {
-    var url = self.base.url + '/_settings';
-    request.get(url, function(err, response) {
+    var esRequest = {
+      'url': self.base.url + '/_settings',
+      'method': 'GET'
+    };
+    self.aws4signer(esRequest);
+
+    request.get(esRequest, function(err, response) {
       self.gotSettings = true;
       var payload = [];
       if (!err) {
@@ -92,6 +103,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
       "sort": [ "_doc" ],
       "body": JSON.stringify(searchBody)
     };
+    self.aws4signer(searchRequest);
 
     request.get(searchRequest, function requestResonse(err, response) {
       if (err) {
@@ -139,7 +151,13 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
   if (self.haveSetMapping === true) {
     callback(null, 0);
   } else {
-    request.put(self.base.url, function(err, response) { // ensure the index exists
+    var esRequest = {
+      'url': self.base.url,
+      'method': 'PUT'
+    };
+    self.aws4signer(esRequest);
+
+    request.put(esRequest, function(err, response) { // ensure the index exists
       try {
         data = data[0];
       } catch (e) {
@@ -168,10 +186,12 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
 
           var payload = {
             url: url,
+            method: 'PUT',
             body: JSON.stringify(set.data),
             timeout: self.parent.options.timeout,
           };
 
+          self.aws4signer(payload);
           request.put(payload, function(err, response) { // upload the mapping
             started--;
             if (!err) {
@@ -217,11 +237,14 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
           }
         }
 
-        var closeUrl = self.base.url + '/_close'; // close the index
-        request.post({
-          url: closeUrl,
-          timeout: self.parent.options.timeout
-        }, function(err, response, body) {
+        var esRequest = {
+              'url': self.base.url + '/_close', // close the index
+              'method': 'POST',
+              'timeout': self.parent.options.timeout
+            };
+        self.aws4signer(esRequest);
+
+        request.post(esRequest, function(err, response, body) {
           if (!err) {
             var bodyError = jsonParser.parse(response.body).error;
             if (bodyError) {
@@ -229,9 +252,12 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
             }
             var payload = {
               url: url,
+              method: 'PUT',
               body: JSON.stringify(setting),
               timeout: self.parent.options.timeout
             };
+            self.aws4signer(payload);
+
             request.put(payload, function(err, response) { // upload the analysis settings
               started--;
               if (!err) {
@@ -244,11 +270,14 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
               }
               if (started === 0) {
                 self.haveSetAnalyzer = true;
-                var openUrl = self.base.url + '/_open'; // open the index
-                request.post({
-                  url: openUrl,
-                  timeout: self.parent.options.timeout
-                }, function(err, response) {
+                var esRequest = {
+                      'url': self.base.url + '/_open', // open the index
+                      'method': "POST",
+                      'timeout': self.parent.options.timeout
+                    };
+                self.aws4signer(esRequest);
+
+                request.post(esRequest, function(err, response) {
                   if (!err) {
                     var bodyError = jsonParser.parse(response.body).error;
                     if (bodyError) {
@@ -269,9 +298,20 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
   if (self.haveSetAnalyzer === true) {
     callback(null, 0);
   } else {
-    request.put(self.base.url, function(err, response) { // ensure the index exists
+    var esRequest = {
+      'url': self.base.url,
+      'method': 'PUT'
+    };
+    self.aws4signer(esRequest);
+
+    request.put(esRequest, function(err, response) { // ensure the index exists
       // use cluster health api to check if the index is ready
-      request.get(self.base.host + '/_cluster/health/' + self.base.index + '?wait_for_status=green', updateAnalyzer);
+      esRequest = {
+        'url': self.base.host + '/_cluster/health/' + self.base.index + '?wait_for_status=green',
+        'method': "GET"
+      };
+      self.aws4signer(esRequest);
+      request.get(esRequest, updateAnalyzer);
     });
   }
 };
@@ -289,6 +329,7 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback) {
   var payload = {
       url:  thisUrl,
       body: '',
+      method: 'PUT',
       timeout: self.parent.options.timeout,
   };
 
@@ -322,6 +363,7 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback) {
 
   self.parent.emit('debug', 'thisUrl: ' + thisUrl + ", payload.body: " + JSON.stringify(payload.body));
 
+  self.aws4signer(payload);
   request.put(payload, function(err, response){
     var writes = 0;
     try{
@@ -349,7 +391,13 @@ elasticsearch.prototype.del = function(elem, callback) {
   var thisUrl = self.base.url + "/" + encodeURIComponent(elem._type) + "/" + encodeURIComponent(elem._id);
 
   self.parent.emit('debug', 'deleteUrl: ' + thisUrl);
-  request.del(thisUrl, function(err, response, body) {
+  var esRequest = {
+        'url': thisUrl,
+        'method': 'DELETE'
+      };
+  self.aws4signer(esRequest);
+
+  request.del(esRequest, function(err, response, body) {
     if (typeof callback === 'function') {
       callback(err, response, body);
     }
@@ -358,12 +406,50 @@ elasticsearch.prototype.del = function(elem, callback) {
 
 elasticsearch.prototype.reindex = function(callback) {
   var self = this;
-  request.post(self.base.url + "/_refresh", function(err, response) {
+
+  var esRequest = {
+      'url': self.base.url + "/_refresh",
+      'method': "POST"
+  };
+  self.aws4signer(esRequest);
+
+  request.post(esRequest, function(err, response) {
     callback(err, response);
   });
 };
 
+elasticsearch.prototype.aws4signer = function(es_request) {
+    var self = this;
+    var awsAccessKeyId = self.parent.options.awsAccessKeyId;
+    var awsSecretAccessKey = self.parent.options.awsSecretAccessKey;
+
+    var useAwsCredentials = (awsAccessKeyId !== null && awsSecretAccessKey !== null );
+
+    self.parent.emit('debug', 'useAwsCredentials: ' + useAwsCredentials + ', awsAccessKeyId: ' + awsAccessKeyId);
+
+    if (useAwsCredentials) {
+      // get aws required stuff from uri or url
+      var es_url = '';
+      if ((es_request.uri !== undefined) && (es_request.uri !== null)) {
+        es_url = es_request.uri;
+      } else if((es_request.url !== undefined) && (es_request.url !== null)) {
+        es_url = es_request.url;
+      }
+
+      const url = require('url');
+      var urlObj = url.parse(es_url);
+
+      es_request.headers =  { 'host': urlObj.hostname};
+      es_request.path = urlObj.path;
+
+      aws4.sign(es_request, {"accessKeyId": awsAccessKeyId, "secretAccessKey": awsSecretAccessKey});
+    }
+
+};
+
 exports.elasticsearch = elasticsearch;
+
+
 
 /////////////
 // HELPERS //
@@ -415,9 +501,10 @@ function scrollResultSet(self, callback, loadedHits){
 
     var scrollRequest = {
       "uri": self.base.host + "/_search" + "/scroll?scroll=" + self.parent.options.scrollTime,
-      "method": "POST",
+      "method": "GET",
       "body": self.lastScrollId
     };
+    self.aws4signer(scrollRequest);
 
     request.get(scrollRequest, function requestResonse(err, response) {
       if (err) {

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -1,7 +1,7 @@
 var request = require('request');
 var jsonParser = require('../jsonparser.js');
 var parseBaseURL = require('../parse-base-url');
-var aws4 = require('aws4');
+var aws4signer = require('../aws4signer');
 
 var elasticsearch = function(parent, url, index) {
   this.base = parseBaseURL(url, index);
@@ -35,7 +35,7 @@ elasticsearch.prototype.getMapping = function(limit, offset, callback) {
       'url': self.base.url + '/_mapping',
       'method': 'GET'
     };
-    self.aws4signer(esRequest);
+    aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.get(esRequest, function(err, response) {
       self.gotMapping = true;
@@ -57,7 +57,7 @@ elasticsearch.prototype.getSettings = function(limit, offset, callback) {
       'url': self.base.url + '/_settings',
       'method': 'GET'
     };
-    self.aws4signer(esRequest);
+    aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.get(esRequest, function(err, response) {
       self.gotSettings = true;
@@ -103,7 +103,7 @@ elasticsearch.prototype.getData = function(limit, offset, callback) {
       "sort": [ "_doc" ],
       "body": JSON.stringify(searchBody)
     };
-    self.aws4signer(searchRequest);
+    aws4signer(searchRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.get(searchRequest, function requestResonse(err, response) {
       if (err) {
@@ -155,7 +155,7 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
       'url': self.base.url,
       'method': 'PUT'
     };
-    self.aws4signer(esRequest);
+    aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.put(esRequest, function(err, response) { // ensure the index exists
       try {
@@ -190,8 +190,8 @@ elasticsearch.prototype.setMapping = function(data, limit, offset, callback) {
             body: JSON.stringify(set.data),
             timeout: self.parent.options.timeout,
           };
+          aws4signer(payload, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
-          self.aws4signer(payload);
           request.put(payload, function(err, response) { // upload the mapping
             started--;
             if (!err) {
@@ -242,7 +242,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
               'method': 'POST',
               'timeout': self.parent.options.timeout
             };
-        self.aws4signer(esRequest);
+        aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
         request.post(esRequest, function(err, response, body) {
           if (!err) {
@@ -256,7 +256,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
               body: JSON.stringify(setting),
               timeout: self.parent.options.timeout
             };
-            self.aws4signer(payload);
+            aws4signer(payload, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
             request.put(payload, function(err, response) { // upload the analysis settings
               started--;
@@ -275,7 +275,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
                       'method': "POST",
                       'timeout': self.parent.options.timeout
                     };
-                self.aws4signer(esRequest);
+                aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
                 request.post(esRequest, function(err, response) {
                   if (!err) {
@@ -302,7 +302,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
       'url': self.base.url,
       'method': 'PUT'
     };
-    self.aws4signer(esRequest);
+    aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.put(esRequest, function(err, response) { // ensure the index exists
       // use cluster health api to check if the index is ready
@@ -310,7 +310,7 @@ elasticsearch.prototype.setAnalyzer = function(data, limit, offset, callback) {
         'url': self.base.host + '/_cluster/health/' + self.base.index + '?wait_for_status=green',
         'method': "GET"
       };
-      self.aws4signer(esRequest);
+      aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
       request.get(esRequest, updateAnalyzer);
     });
   }
@@ -363,7 +363,7 @@ elasticsearch.prototype.setData = function(data, limit, offset, callback) {
 
   self.parent.emit('debug', 'thisUrl: ' + thisUrl + ", payload.body: " + JSON.stringify(payload.body));
 
-  self.aws4signer(payload);
+  aws4signer(payload, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
   request.put(payload, function(err, response){
     var writes = 0;
     try{
@@ -395,7 +395,7 @@ elasticsearch.prototype.del = function(elem, callback) {
         'url': thisUrl,
         'method': 'DELETE'
       };
-  self.aws4signer(esRequest);
+  aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
   request.del(esRequest, function(err, response, body) {
     if (typeof callback === 'function') {
@@ -411,45 +411,14 @@ elasticsearch.prototype.reindex = function(callback) {
       'url': self.base.url + "/_refresh",
       'method': "POST"
   };
-  self.aws4signer(esRequest);
+  aws4signer(esRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
   request.post(esRequest, function(err, response) {
     callback(err, response);
   });
 };
 
-elasticsearch.prototype.aws4signer = function(es_request) {
-    var self = this;
-    var awsAccessKeyId = self.parent.options.awsAccessKeyId;
-    var awsSecretAccessKey = self.parent.options.awsSecretAccessKey;
-
-    var useAwsCredentials = (awsAccessKeyId !== null && awsSecretAccessKey !== null );
-
-    self.parent.emit('debug', 'useAwsCredentials: ' + useAwsCredentials + ', awsAccessKeyId: ' + awsAccessKeyId);
-
-    if (useAwsCredentials) {
-      self.parent.emit('debug', 'useAwsCredentials: ' + useAwsCredentials + ', awsAccessKeyId: ' + awsAccessKeyId);
-      // get aws required stuff from uri or url
-      var es_url = '';
-      if ((es_request.uri !== undefined) && (es_request.uri !== null)) {
-        es_url = es_request.uri;
-      } else if((es_request.url !== undefined) && (es_request.url !== null)) {
-        es_url = es_request.url;
-      }
-
-      const url = require('url');
-      var urlObj = url.parse(es_url);
-
-      es_request.headers =  { 'host': urlObj.hostname};
-      es_request.path = urlObj.path;
-
-      aws4.sign(es_request, {"accessKeyId": awsAccessKeyId, "secretAccessKey": awsSecretAccessKey});
-    }
-
-};
-
 exports.elasticsearch = elasticsearch;
-
 
 
 /////////////
@@ -505,7 +474,7 @@ function scrollResultSet(self, callback, loadedHits){
       "method": "GET",
       "body": self.lastScrollId
     };
-    self.aws4signer(scrollRequest);
+    aws4signer(scrollRequest, self.parent.options.awsAccessKeyId, self.parent.options.awsSecretAccessKey);
 
     request.get(scrollRequest, function requestResonse(err, response) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -9,15 +9,29 @@
     "url": "git://github.com/taskrabbit/elasticsearch-dump.git"
   },
   "main": "elasticdump.js",
-  "keywords": ["elasticsearch", "dump", "elasticdump", "import", "export", "transfer", "migrate", "migartion", "elasitic", "cluster", "elastic-dump", "elastic dump"],
+  "keywords": [
+    "elasticsearch",
+    "dump",
+    "elasticdump",
+    "import",
+    "export",
+    "transfer",
+    "migrate",
+    "migartion",
+    "elasitic",
+    "cluster",
+    "elastic-dump",
+    "elastic dump"
+  ],
   "engines": {
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "optimist": "latest",
-    "request": "2.x.x",
     "JSONStream": "1.1.x",
-    "async": "1.x.x"
+    "async": "1.x.x",
+    "aws4": "^1.4.1",
+    "optimist": "latest",
+    "request": "2.x.x"
   },
   "devDependencies": {
     "mocha": "latest",

--- a/test/aws4signing.js
+++ b/test/aws4signing.js
@@ -1,0 +1,70 @@
+var should = require('should');
+var aws4signer = require('../lib/aws4signer');
+
+describe('aws4signer', function () {
+	it('should parse "uri" from request object and add signature, if credentials provided', function() {
+		var r = {
+			uri : 'http://127.0.0.1:9200/_search?q=test',
+			method : 'GET',
+			body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+		};
+		aws4signer(r, 'key', 'secret');
+
+		r.should.have.property('headers').which.is.an.Object;
+		r.headers.should.have.property('host').which.is.a.String();
+		r.headers.should.have.property('Content-Type').which.is.a.String();
+		r.headers.should.have.property('Content-Length').which.is.a.Number();
+		r.headers.should.have.property('X-Amz-Date').which.is.a.String();
+		r.headers.should.have.property('Authorization').which.containEql('Credential');
+		r.headers.should.have.property('Authorization').which.containEql('SignedHeaders');
+		r.should.have.property('path');
+		r.should.have.property('hostname');
+	});
+
+	it('should parse "url" from request object and add signature, if credentials provided', function() {
+		var r = {
+			url : 'http://127.0.0.1:9200/_search?q=test',
+			method : 'GET',
+			body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+		};
+		aws4signer(r, 'key', 'secret');
+
+		r.should.have.property('headers').which.is.an.Object;
+		r.headers.should.have.property('host').which.is.a.String();
+		r.headers.should.have.property('Content-Type').which.is.a.String();
+		r.headers.should.have.property('Content-Length').which.is.a.Number();
+		r.headers.should.have.property('X-Amz-Date').which.is.a.String();
+		r.headers.should.have.property('Authorization').which.containEql('Credential');
+		r.headers.should.have.property('Authorization').which.containEql('SignedHeaders');
+		r.should.have.property('path');
+		r.should.have.property('hostname');
+	});
+
+	it('should not add signature if credential (key, secret) is NOT provided', function() {
+		var r = {
+			uri : 'http://127.0.0.1:9200/_search?q=test',
+			method : 'GET',
+			body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+		};
+		aws4signer(r);
+
+		if(r.headers !== undefined) {
+			r.headers.should.not.have.property('X-Amz-Date');
+			r.headers.should.not.have.property('Authorization');
+		}
+	});
+
+	it('should not add signature if credential (secret or key) is NOT provided', function() {
+		var r = {
+			uri : 'http://127.0.0.1:9200/_search?q=test',
+			method : 'GET',
+			body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+		};
+		aws4signer(r, 'keyORsecret');
+
+		if(r.headers !== undefined) {
+			r.headers.should.not.have.property('X-Amz-Date');
+			r.headers.should.not.have.property('Authorization');
+		}
+	});
+});


### PR DESCRIPTION
If you are using Amazon Elasticsearch hosted solution, you have probaly protected the service using IAM roles. In that case you need to sign every request to Elasticsearch with Signature Version 4. This patch makes use of 'aws4' to create correct signing when using the REST API.

* http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
* https://www.npmjs.com/package/aws4
