### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ The limited option set includes:
 - `output`:     `null`,
 - `scrollTime`: `'10m'`,
 - `limit`:      `100`,
-- `offset`:     `100`,
+- `offset`:     `0`,
 - `direction`:   `dump`
 
 If the `--direction` is `dump`, which is the default, `--input` MUST be a URL for the base location of an ElasticSearch server (i.e. `http://localhost:9200`) and `--output` MUST be a directory. Each index that does match will have a data, mapping, and analyzer file created.


### PR DESCRIPTION
The `multielasticdump` option set that showed the offset to `100` was somewhat misleading, as it made it look like a default.  Updated to set it to 0, so that folks (like myself) don't feel confused by setting the number to something like 100 by default.