### PR TITLE
Added optional sessionToken to signer

### DIFF
--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -18,7 +18,11 @@ aws4signer = function(es_request, parent) {
       es_request.headers =  { 'host': urlObj.hostname};
       es_request.path = urlObj.path;
 
-      aws4.sign(es_request, {"accessKeyId": parent.options.awsAccessKeyId, "secretAccessKey": parent.options.awsSecretAccessKey});
+      aws4.sign(es_request, {
+        accessKeyId: parent.options.awsAccessKeyId,
+        secretAccessKey: parent.options.awsSecretAccessKey,
+        sessionToken: parent.options.sessionToken
+      });
     }
 };
 


### PR DESCRIPTION
To make it possible use [Temporary Security Credentials](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) you need to supply a session token in addition to the access and secret keys.

aws4 already supports this, so the only change is the one suggested here.