### PR TITLE
add ability to load aws creds from ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     When using Amazon Elasticsearch Service proteced by
                     AWS Identity and Access Management (IAM), provide
                     your Access Key ID and Secret Access Key
+--awsIniFileProfile
+                    Alternative to --awsAccessKeyId and --awsSecretAccessKey,
+                    loads credentials from profile aws ini file
+--awsIniFileName
+                    Override the default aws ini file name when using --awsIniFileProfile 
+                    (default: config)
 --help
                     This page
 ```

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -30,6 +30,8 @@ var defaults = {
   quiet:              false,
   awsAccessKeyId:     null,
   awsSecretAccessKey: null,
+  awsIniFileProfile:  null,
+  awsIniFileName:     null
 };
 
 var options = {};

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -1,9 +1,11 @@
 var aws4 = require('aws4');
+var awscred = require('awscred');
 
 aws4signer = function(es_request, parent) {
     var useAwsCredentials = ((typeof parent.options.awsAccessKeyId == 'string') && (typeof parent.options.awsSecretAccessKey == 'string'));
-
-    if (useAwsCredentials) {
+    var useAwsProfile = (typeof parent.options.awsIniFileProfile == 'string');
+    
+    if (useAwsCredentials || useAwsProfile) {
       // get aws required stuff from uri or url
       var es_url = '';
       if ((es_request.uri !== undefined) && (es_request.uri !== null)) {
@@ -14,14 +16,24 @@ aws4signer = function(es_request, parent) {
 
       const url = require('url');
       var urlObj = url.parse(es_url);
-
+      
       es_request.headers =  { 'host': urlObj.hostname};
       es_request.path = urlObj.path;
-
+    }
+  
+    if (useAwsCredentials) {
       aws4.sign(es_request, {
         accessKeyId: parent.options.awsAccessKeyId,
         secretAccessKey: parent.options.awsSecretAccessKey,
         sessionToken: parent.options.sessionToken
+      });
+    } else if (useAwsProfile) {
+      var awsIniFileName = parent.options.awsIniFileName ? parent.options.awsIniFileName : 'config';
+      var creds = awscred.loadProfileFromIniFileSync({profile: parent.options.awsIniFileProfile}, awsIniFileName);
+      aws4.sign(es_request, {
+        accessKeyId: creds.aws_access_key_id,
+        secretAccessKey: creds.aws_secret_access_key,
+        sessionToken: creds.aws_session_token
       });
     }
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "JSONStream": "^1.2.0",
     "async": "^2.0.1",
     "aws4": "^1.4.1",
+    "awscred": "^1.2.0",
     "optimist": "latest",
     "request": "2.x.x"
   },


### PR DESCRIPTION
Add --awsIniFileProfile and --awsIniFileName options to allow loading AWS credentials from a profile stored in an AWS INI file (i.e. ~/.aws/config).