### PR TITLE
New option to transform documents by script

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -31,7 +31,8 @@ var defaults = {
   awsAccessKeyId: null,
   awsSecretAccessKey: null,
   awsIniFileProfile: null,
-  awsIniFileName: null
+  awsIniFileName: null,
+  transform: null
 }
 
 var options = {}

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -62,8 +62,7 @@ var elasticdump = function (input, output, options) {
 
   if (self.options.type === 'data' && self.options.transform) {
     var modificationScriptText = '(function(doc) { ' + self.options.transform + ' })'
-    var modificationScript = new vm.Script(modificationScriptText)
-    self.modifier =  modificationScript.runInNewContext()
+    self.modifier = new vm.Script(modificationScriptText)
   }
 }
 
@@ -111,8 +110,8 @@ elasticdump.prototype.dump = function (callback, continuing, limit, offset, tota
         self.log('Warning: offseting ' + self.options.offset + ' rows.')
         self.log("  * Using an offset doesn't guarantee that the offset rows have already been written, please refer to the HELP text.")
       }
-      if(self.modifier) {
-        self.log("Will modify documents using this script: " + self.options.transform)
+      if (self.modifier) {
+        self.log('Will modify documents using this script: ' + self.options.transform)
       }
     }
 
@@ -120,8 +119,8 @@ elasticdump.prototype.dump = function (callback, continuing, limit, offset, tota
       if (err) { self.emit('error', err) }
       if (!err || (self.options['ignore-errors'] === true || self.options['ignore-errors'] === 'true')) {
         self.log('got ' + data.length + ' objects from source ' + self.inputType + ' (offset: ' + offset + ')')
-        if(self.modifier) {
-          for(var i = 0; i < data.length; i++) {
+        if (self.modifier) {
+          for (var i = 0; i < data.length; i++) {
             self.modifier(data[i])
           }
         }

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -62,7 +62,7 @@ var elasticdump = function (input, output, options) {
 
   if (self.options.type === 'data' && self.options.transform) {
     var modificationScriptText = '(function(doc) { ' + self.options.transform + ' })'
-    self.modifier = new vm.Script(modificationScriptText)
+    self.modifier = new vm.Script(modificationScriptText).runInNewContext()
   }
 }
 

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -86,6 +86,13 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     When using Amazon Elasticsearch Service proteced by
                     AWS Identity and Access Management (IAM), provide
                     your Access Key ID and Secret Access Key
+--transform
+                    A javascript, which will be called to modify documents
+                    before writing it to destination. global variable 'doc'
+                    is available.
+                    Example script for computing a new field 'f2' as doubled
+                    value of field 'f1':
+                        doc._source["f2"] = doc._source.f1 * 2;
 
 --help
                     This page

--- a/test/transform.js
+++ b/test/transform.js
@@ -1,0 +1,93 @@
+'use strict'
+
+/*
+ * Test suite for transforming documents during copying
+ */
+var baseUrl = 'http://127.0.0.1:9200'
+var indexes = ['source_index', 'destination_index']
+var ids = [1, 2]
+var request = require('request')
+var should = require('should')
+var path = require('path')
+var async = require('async')
+var Elasticdump = require(path.join(__dirname, '..', 'elasticdump.js'))
+
+var clear = function (callback) {
+  var jobs = []
+  indexes.forEach(function (index) {
+    jobs.push(function (done) {
+      request.del(baseUrl + '/' + index, done)
+    })
+  })
+  async.series(jobs, callback)
+}
+
+var setup = function (callback) {
+  var jobs = []
+
+  jobs.push(function (done) {
+    var url = baseUrl + '/source_index'
+    request.put(url, {body: JSON.stringify({mappings: {test: {}}})}, done)
+  })
+  ids.forEach(function (i) {
+    jobs.push(function (done) {
+      var url = baseUrl + '/source_index/test/' + i
+      var payload = JSON.stringify({foo: i})
+      request.put(url, {body: payload}, done)
+    })
+  })
+
+  jobs.push(function (done) {
+    setTimeout(done, 6000)
+  })
+
+  async.series(jobs, callback)
+}
+
+describe('transform script should be executed for written documents', function () {
+  before(function (done) {
+    this.timeout(1000 * 20)
+    clear(function (error) {
+      if (error) { return done(error) }
+      setup(function (error) {
+        if (error) { return done(error) }
+        var jobs = []
+
+        var dataOptions = {
+          limit: 100,
+          offset: 0,
+          debug: true,
+          type: 'data',
+          input: baseUrl + '/source_index',
+          output: baseUrl + '/destination_index',
+          scrollTime: '10m',
+          transform: 'doc._source["bar"] = doc._source.foo * 2'
+        }
+
+        var dataDumper = new Elasticdump(dataOptions.input, dataOptions.output, dataOptions)
+
+        dataDumper.on('error', function (error) { throw (error) })
+
+        jobs.push(function (next) { dataDumper.dump(next) })
+        jobs.push(function (next) { setTimeout(next, 5001) })
+
+        async.series(jobs, done)
+      })
+    })
+  })
+
+  after(function (done) { clear(done) })
+
+  it('documents should have the new field computed by transform script', function (done) {
+    var url = baseUrl + '/destination_index/_search'
+    request.get(url, function (err, response, body) {
+      should.not.exist(err)
+      body = JSON.parse(body)
+      body.hits.total.should.equal(2)
+      body.hits.hits.forEach(function (doc) {
+        doc._source.bar.should.equal(doc._source.foo * 2)
+      })
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Hi,
I would like to propose a modification implementing new option in which the user can provide simple script to modify the dumped data documents. Example call:
Example command which will copy documents and adds a new field 'f2' as doubled value of field 'f1' to each of them:
`elasticdump --input=... --output=... --transform='doc._source["f2"]=doc._source.f1*2'`
