### PR TITLE
Added User-Agent header to elasticsearch HTTP(S) transport

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -11,6 +11,7 @@ var elasticsearch = function (parent, url, index) {
   this.elementsToSkip = 0
   this.searchBody = this.parent.options.searchBody
   this.ESversion = null
+  this.baseRequest = request.defaults({headers: { 'User-Agent': 'elasticdump' }})
 }
 // accept callback
 // return (error, arr) where arr is an array of objects
@@ -37,7 +38,7 @@ elasticsearch.prototype.version = function (prefix, callback) {
 
   if (self.ESversion) { return callback() }
 
-  request.get(self.base.host, function (err, response) {
+  self.baseRequest.get(self.base.host, function (err, response) {
     if (err) { return callback(err) }
     response = JSON.parse(response.body)
 
@@ -72,7 +73,7 @@ elasticsearch.prototype.getMapping = function (limit, offset, callback) {
     }
     aws4signer(esRequest, self.parent)
 
-    request.get(esRequest, function (err, response) {
+    self.baseRequest.get(esRequest, function (err, response) {
       self.gotMapping = true
       var payload = []
       if (!err) {
@@ -94,7 +95,7 @@ elasticsearch.prototype.getSettings = function (limit, offset, callback) {
     }
     aws4signer(esRequest, self.parent)
 
-    request.get(esRequest, function (err, response) {
+    self.baseRequest.get(esRequest, function (err, response) {
       self.gotSettings = true
       var payload = []
       if (!err) {
@@ -140,7 +141,7 @@ elasticsearch.prototype.getData = function (limit, offset, callback) {
     }
     aws4signer(searchRequest, self.parent)
 
-    request.get(searchRequest, function requestResonse (err, response) {
+    self.baseRequest.get(searchRequest, function requestResonse (err, response) {
       if (err) {
         callback(err, [])
         return
@@ -196,7 +197,7 @@ elasticsearch.prototype.setMapping = function (data, limit, offset, callback) {
     }
     aws4signer(esRequest, self.parent)
 
-    request.put(esRequest, function (err, response) { // ensure the index exists
+    self.baseRequest.put(esRequest, function (err, response) { // ensure the index exists
       if (err) { return callback(err) }
 
       try {
@@ -233,7 +234,7 @@ elasticsearch.prototype.setMapping = function (data, limit, offset, callback) {
 
           aws4signer(payload, self.parent)
 
-          request.put(payload, function (err, response) { // upload the mapping
+          self.baseRequest.put(payload, function (err, response) { // upload the mapping
             started--
             if (!err) {
               var bodyError = jsonParser.parse(response.body).error
@@ -287,7 +288,7 @@ elasticsearch.prototype.setAnalyzer = function (data, limit, offset, callback) {
         }
         aws4signer(esRequest, self.parent)
 
-        request.post(esRequest, function (err, response, body) {
+        self.baseRequest.post(esRequest, function (err, response, body) {
           if (!err) {
             var bodyError = jsonParser.parse(response.body).error
             if (bodyError) {
@@ -301,7 +302,7 @@ elasticsearch.prototype.setAnalyzer = function (data, limit, offset, callback) {
             }
             aws4signer(payload, self.parent)
 
-            request.put(payload, function (err, response) { // upload the analysis settings
+            self.baseRequest.put(payload, function (err, response) { // upload the analysis settings
               started--
               if (!err) {
                 var bodyError = jsonParser.parse(response.body).error
@@ -320,7 +321,7 @@ elasticsearch.prototype.setAnalyzer = function (data, limit, offset, callback) {
                 }
                 aws4signer(esRequest, self.parent)
 
-                request.post(esRequest, function (err, response) {
+                self.baseRequest.post(esRequest, function (err, response) {
                   if (!err) {
                     var bodyError = jsonParser.parse(response.body).error
                     if (bodyError) {
@@ -347,7 +348,7 @@ elasticsearch.prototype.setAnalyzer = function (data, limit, offset, callback) {
     }
     aws4signer(esRequest, self.parent)
 
-    request.put(esRequest, function (err, response) { // ensure the index exists
+    self.baseRequest.put(esRequest, function (err, response) { // ensure the index exists
       if (err) { return callback(err) }
 
       // use cluster health api to check if the index is ready
@@ -356,7 +357,7 @@ elasticsearch.prototype.setAnalyzer = function (data, limit, offset, callback) {
         'method': 'GET'
       }
       aws4signer(esRequest, self.parent)
-      request.get(esRequest, updateAnalyzer)
+      self.baseRequest.get(esRequest, updateAnalyzer)
     })
   }
 }
@@ -408,7 +409,7 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
   self.parent.emit('debug', 'thisUrl: ' + thisUrl + ', payload.body: ' + JSON.stringify(payload.body))
 
   aws4signer(payload, self.parent)
-  request.put(payload, function (err, response) {
+  self.baseRequest.put(payload, function (err, response) {
     if (err) { return callback(err) }
 
     try {
@@ -441,7 +442,7 @@ elasticsearch.prototype.del = function (elem, callback) {
   }
   aws4signer(esRequest, self.parent)
 
-  request.del(esRequest, function (err, response, body) {
+  self.baseRequest.del(esRequest, function (err, response, body) {
     if (typeof callback === 'function') {
       callback(err, response, body)
     }
@@ -457,7 +458,7 @@ elasticsearch.prototype.reindex = function (callback) {
   }
   aws4signer(esRequest, self.parent)
 
-  request.post(esRequest, function (err, response) {
+  self.baseRequest.post(esRequest, function (err, response) {
     callback(err, response)
   })
 }
@@ -514,7 +515,7 @@ function scrollResultSet (self, callback, loadedHits) {
     }
     aws4signer(scrollRequest, self.parent)
 
-    request.get(scrollRequest, function requestResonse (err, response) {
+    self.baseRequest.get(scrollRequest, function requestResonse (err, response) {
       if (err) {
         callback(err, [])
         return

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,18 @@ describe('ELASTICDUMP', function () {
     })
   })
 
+  it('sets User-Agent', function (done) {
+    var Elasticsearch = require(path.join(__dirname, '../lib/transports', 'elasticsearch'))['elasticsearch']
+    this.timeout(testTimeout)
+    var parent = { options: { searchBody: 'none' } }
+    var es = (new Elasticsearch(parent, baseUrl, 'source_index'))
+    es.baseRequest(baseUrl, function (err, response, body) {
+      should.not.exist(err)
+      response.req._headers['user-agent'].should.equal('elasticdump')
+      done()
+    })
+  })
+
   describe('es to es', function () {
     it('works for a whole index', function (done) {
       this.timeout(testTimeout)


### PR DESCRIPTION
This PR adds a User-Agent header to any HTTP or HTTPS requests.

This is valuable for a number of reasons: 
* analysis of ES request logs
* if a reverse proxy is implemented in front of the ES cluster, allow more intelligent behaviour (e.g. by default redirect to Kibana, but if U-A matches elasticdump then allow access to the REST endpoint)
* more compliant with RFC7231 (which states that we should send a User-Agent)
