### PR TITLE
fix - multielasticdump - special chars in index name

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -232,7 +232,7 @@ var load = function () {
 
   indexCounter++
 
-  var output = options.output + '/' + index
+  var output = options.output + '/' + encodeURIComponent(index)
   var inputData = options.input + '/' + index + '.json'
   var inputMapping = options.input + '/' + index + '.mapping.json'
   var inputAnalyzer = options.input + '/' + index + '.analyzer.json'

--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -144,7 +144,7 @@ var dump = function () {
 
   indexCounter++
 
-  var input = options.input + '/' + index
+  var input = options.input + '/' + encodeURIComponent(index)
   var outputData = options.output + '/' + index + '.json'
   var outputMapping = options.output + '/' + index + '.mapping.json'
   var outputAnalyzer = options.output + '/' + index + '.analyzer.json'


### PR DESCRIPTION
Allows multielasticdump to be used on an Elasticsearch instance containing indexes with special chars.

example of index name crashing multielasticdump: `%index`