### PR TITLE
Fix parent/child out of order mapping pushes

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -2,6 +2,7 @@ var request = require('request')
 var jsonParser = require('../jsonparser.js')
 var parseBaseURL = require('../parse-base-url')
 var aws4signer = require('../aws4signer')
+var async = require('async')
 
 var elasticsearch = function (parent, url, index) {
   this.base = parseBaseURL(url, index)
@@ -220,7 +221,7 @@ elasticsearch.prototype.setMapping = function (data, limit, offset, callback) {
           }
         }
 
-        sortedMappings.forEach(function (set) {
+        async.eachSeries(sortedMappings, function (set) {
           var url = self.base.url + '/' + encodeURIComponent(set.key) + '/_mapping'
           started++
           count++

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -212,7 +212,6 @@ elasticsearch.prototype.setMapping = function (data, limit, offset, callback) {
         var mappings = data[index]['mappings']
         var sortedMappings = []
 
-        // TODO: it seems we need to set the mappings for children with parents first?
         for (var key in mappings) {
           if (mappings[key]._parent) {
             sortedMappings = [{key: key, data: mappings[key]}].concat(sortedMappings)
@@ -220,23 +219,23 @@ elasticsearch.prototype.setMapping = function (data, limit, offset, callback) {
             sortedMappings.push({key: key, data: mappings[key]})
           }
         }
-
-        async.eachSeries(sortedMappings, function (set) {
+        
+        async.eachSeries(sortedMappings, function(set, cb) {
           var url = self.base.url + '/' + encodeURIComponent(set.key) + '/_mapping'
-          started++
-          count++
-
           var payload = {
             url: url,
             method: 'PUT',
             body: JSON.stringify(set.data),
             timeout: self.parent.options.timeout
           }
-
           aws4signer(payload, self.parent)
-
-          self.baseRequest.put(payload, function (err, response) { // upload the mapping
+          
+          started++
+          count++
+          
+          self.baseRequest.put(payload, function(err, response) {
             started--
+            cb(null) // we always call this with no error because this is a dirty hack and we are already handling errors...
             if (!err) {
               var bodyError = jsonParser.parse(response.body).error
               if (bodyError) {


### PR DESCRIPTION
Addresses issue...
https://github.com/taskrabbit/elasticsearch-dump/issues/226

This is a pretty dirty hack and realistically I won't have time to clean this up, so this is more for visibility.

Is there a reason async isn't being used in this file already?