### PR TITLE
Aws signing enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tools for moving and saving indicies.
 
 (local)
 ```bash
-npm install elasticdump
+npm install
 ./bin/elasticdump
 ```
 

--- a/README.md
+++ b/README.md
@@ -262,16 +262,24 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Example script for computing a new field 'f2' as doubled
                     value of field 'f1':
                         doc._source["f2"] = doc._source.f1 * 2;
+--awsChain
+                    Use [standard](https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/) location and ordering for resolving credentials including environment variables, config files, EC2 and ECS metadata locations
+                    _Recommended option for use with AWS_ 
 --awsAccessKeyId
 --awsSecretAccessKey
                     When using Amazon Elasticsearch Service proteced by
                     AWS Identity and Access Management (IAM), provide
-                    your Access Key ID and Secret Access Key
+                    your Access Key ID and Secret Access Key.
+                    --sessionToken can also be optionally provided if using temporary credentials
 --awsIniFileProfile
                     Alternative to --awsAccessKeyId and --awsSecretAccessKey,
-                    loads credentials from profile aws ini file
+                    loads credentials from a specified profile in aws ini file.
+                    For greater flexibility, consider using --awsChain
+                    and setting AWS_PROFILE and AWS_CONFIG_FILE
+                    environment variables to override defaults if needed
 --awsIniFileName
                     Override the default aws ini file name when using --awsIniFileProfile
+                    Filename is relative to ~/.aws/ 
                     (default: config)
 --help
                     This page

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -28,6 +28,7 @@ var defaults = {
   timeout: null,
   toLog: null,
   quiet: false,
+  awsChain: false,
   awsAccessKeyId: null,
   awsSecretAccessKey: null,
   awsIniFileProfile: null,

--- a/docker-compose-test-helper.yml
+++ b/docker-compose-test-helper.yml
@@ -1,0 +1,16 @@
+# To aid in running tests locally. NOT for using elasicdump as a Docker container
+version: '2.1'
+services:
+  elasticsearch:
+    ports:
+      - "9200:9200"
+    image: 'docker.elastic.co/elasticsearch/elasticsearch:5.3.0'
+    environment:
+      http.host: '0.0.0.0'
+      transport.host: '127.0.0.1'
+      xpack.security.enabled: 'false' # ES5 ships with security on by default which isn't configured in unit tests 
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 2s
+      timeout: 2s
+      retries: 5

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -1,12 +1,43 @@
 var aws4 = require('aws4')
-var awscred = require('awscred')
+var AWS = require('aws-sdk')
+var path = require('path')
+var os = require('os')
+
+var credentials // lazily loaded, see below
 
 var aws4signer = function (esRequest, parent) {
+  // Consider deprecating - insecure to use on command line and credentials can be found by default at ~/.aws/credentials or as environment variables
   var useAwsCredentials = ((typeof parent.options.awsAccessKeyId === 'string') && (typeof parent.options.awsSecretAccessKey === 'string'))
+  // Consider deprecating - can be achieved with awsChain and setting AWS_PROFILE and AWS_CONFIG_FILE environment variables as needed
   var useAwsProfile = (typeof parent.options.awsIniFileProfile === 'string')
+  var useAwsChain = (parent.options.awsChain === true)
 
-  if (useAwsCredentials || useAwsProfile) {
-      // get aws required stuff from uri or url
+  if (useAwsCredentials || useAwsProfile || useAwsChain) {
+    // Lazy load credentials object depending on our flavor of credential loading
+    // Assumption is that loading only needs to happen once per execution and if refreshing is
+    // needed, credentials object should implement credentials.refresh() callback
+    if (!credentials) {
+      if (useAwsChain) {
+        new AWS.CredentialProviderChain().resolve(function (err, resolved) {
+          if (err) { throw err } else {
+            credentials = resolved
+          }
+        })
+      } else if (useAwsCredentials) {
+        credentials = {
+          accessKeyId: parent.options.awsAccessKeyId,
+          secretAccessKey: parent.options.awsSecretAccessKey,
+          sessionToken: parent.options.sessionToken
+        }
+      } else if (useAwsProfile) {
+        credentials = new AWS.SharedIniFileCredentials({
+          profile: parent.options.awsIniFileProfile,
+          filename: path.join(os.homedir(), '.aws', parent.options.awsIniFileName ? parent.options.awsIniFileName : 'config')
+        })
+      }
+    }
+
+    // get aws required stuff from uri or url
     var esURL = ''
     if ((esRequest.uri !== undefined) && (esRequest.uri !== null)) {
       esURL = esRequest.uri
@@ -19,22 +50,8 @@ var aws4signer = function (esRequest, parent) {
 
     esRequest.headers = { 'host': urlObj.hostname }
     esRequest.path = urlObj.path
-  }
 
-  if (useAwsCredentials) {
-    aws4.sign(esRequest, {
-      accessKeyId: parent.options.awsAccessKeyId,
-      secretAccessKey: parent.options.awsSecretAccessKey,
-      sessionToken: parent.options.sessionToken
-    })
-  } else if (useAwsProfile) {
-    var awsIniFileName = parent.options.awsIniFileName ? parent.options.awsIniFileName : 'config'
-    var creds = awscred.loadProfileFromIniFileSync({profile: parent.options.awsIniFileProfile}, awsIniFileName)
-    aws4.sign(esRequest, {
-      accessKeyId: creds.aws_access_key_id,
-      secretAccessKey: creds.aws_secret_access_key,
-      sessionToken: creds.aws_session_token
-    })
+    aws4.sign(esRequest, credentials)
   }
 }
 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -37,8 +37,12 @@ elasticsearch.prototype.version = function (prefix, callback) {
   var self = this
 
   if (self.ESversion) { return callback() }
-
-  self.baseRequest.get(self.base.host, function (err, response) {
+  var esRequest = {
+    'url': self.base.host + '/',
+    'method': 'GET'
+  }
+  aws4signer(esRequest, self.parent)
+  self.baseRequest.get(esRequest, function (err, response) {
     if (err) { return callback(err) }
     response = JSON.parse(response.body)
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "async": "^2.0.1",
     "aws4": "^1.4.1",
     "aws-sdk": "^2.36.0",
-    "path": "^0.12.7 ",
     "ini": "^1.3.4",
     "optimist": "latest",
     "request": "2.x.x"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "JSONStream": "^1.2.0",
     "async": "^2.0.1",
     "aws4": "^1.4.1",
-    "awscred": "^1.2.0",
+    "aws-sdk": "^2.36.0",
+    "path": "^0.12.7 ",
     "ini": "^1.3.4",
     "optimist": "latest",
     "request": "2.x.x"

--- a/test/aws4signing.js
+++ b/test/aws4signing.js
@@ -1,6 +1,8 @@
 var should = require('should') // eslint-disable-line
 var aws4signer = require('../lib/aws4signer')
-var parent = {options: {awsAccessKeyId: 'key', awsSecretAccessKey: 'secret'}}
+var credentialsParent = {options: {awsAccessKeyId: 'key', awsSecretAccessKey: 'secret'}}
+var profileParent = {options: {awsIniFileName: 'file', awsIniFileProfile: 'testing'}}
+var chainParent = {options: {awsChain: true}}
 
 describe('aws4signer', function () {
   it('should parse "uri" from request object and add signature, if credentials provided', function () {
@@ -10,17 +12,8 @@ describe('aws4signer', function () {
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
 
-    aws4signer(r, parent)
-
-    r.should.have.property('headers').which.is.an.Object()
-    r.headers.should.have.property('host').which.is.a.String()
-    r.headers.should.have.property('Content-Type').which.is.a.String()
-    r.headers.should.have.property('Content-Length').which.is.a.Number()
-    r.headers.should.have.property('X-Amz-Date').which.is.a.String()
-    r.headers.should.have.property('Authorization').which.containEql('Credential')
-    r.headers.should.have.property('Authorization').which.containEql('SignedHeaders')
-    r.should.have.property('path')
-    r.should.have.property('hostname')
+    aws4signer(r, credentialsParent)
+    assertSigned(r)
   })
 
   it('should parse "url" from request object and add signature, if credentials provided', function () {
@@ -29,17 +22,28 @@ describe('aws4signer', function () {
       method: 'GET',
       body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
     }
-    aws4signer(r, parent)
+    aws4signer(r, credentialsParent)
+    assertSigned(r)
+  })
 
-    r.should.have.property('headers').which.is.an.Object()
-    r.headers.should.have.property('host').which.is.a.String()
-    r.headers.should.have.property('Content-Type').which.is.a.String()
-    r.headers.should.have.property('Content-Length').which.is.a.Number()
-    r.headers.should.have.property('X-Amz-Date').which.is.a.String()
-    r.headers.should.have.property('Authorization').which.containEql('Credential')
-    r.headers.should.have.property('Authorization').which.containEql('SignedHeaders')
-    r.should.have.property('path')
-    r.should.have.property('hostname')
+  it('should parse "url" from request object and add signature, if AWS profile info provided', function () {
+    var r = {
+      url: 'http://127.0.0.1:9200/_search?q=test',
+      method: 'GET',
+      body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+    }
+    aws4signer(r, profileParent)
+    assertSigned(r)
+  })
+
+  it('should parse "url" from request object and add signature, if AWS Chain option provided', function () {
+    var r = {
+      url: 'http://127.0.0.1:9200/_search?q=test',
+      method: 'GET',
+      body: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'
+    }
+    aws4signer(r, chainParent)
+    assertSigned(r)
   })
 
   it('should not add signature if credential (key, secret) is NOT provided', function () {
@@ -69,4 +73,15 @@ describe('aws4signer', function () {
       r.headers.should.not.have.property('Authorization')
     }
   })
+  var assertSigned = function (r) {
+    r.should.have.property('headers').which.is.an.Object()
+    r.headers.should.have.property('host').which.is.a.String()
+    r.headers.should.have.property('Content-Type').which.is.a.String()
+    r.headers.should.have.property('Content-Length').which.is.a.Number()
+    r.headers.should.have.property('X-Amz-Date').which.is.a.String()
+    r.headers.should.have.property('Authorization').which.containEql('Credential')
+    r.headers.should.have.property('Authorization').which.containEql('SignedHeaders')
+    r.should.have.property('path')
+    r.should.have.property('hostname')
+  }
 })


### PR DESCRIPTION
This does a few things & could be broken up as several PRs but since they're mostly related to AWS or just documentation hopefully you'll accept it as one:

1. Signs root "/" request for version so that version can be determined correctly when working with older (< version 5) ES clusters
2. Uses the AWS SDK `CredentialProviderChain` to allow users to specify credentials in a number of standard ways, most importantly adding support to automatically get credentials from the EC2 metadata service or task role credentials in ECS. These really can't be supplied by the command line or as a file as they are automatically rotated every hour. I believe I didn't break any existing command line options, but switched to using `aws-sdk` instead of `awscred` npm module. See:
https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
or for Javascript specifically 
http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CredentialProviderChain.html#defaultProviders-property

3. Small doc enhancements 
4. Adds a `docker-compose` file as an aid to anyone trying to run tests locally as the tests expect an elasticsearch container to be running at localhost:9200. Hopefully this isn't confusing to someone thinking this is a way to run elasticdump in Docker

Happy to rebase this or take out the parts you don't like.

