### PR TITLE
Set custom headers on ES requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Preform a partial extract based on search results
                     (when ES is the input,
                     (default: '{"query": { "match_all": {} }, "fields": ["*"], "_source": true }'))
+--headers
+                    Add custom headers to Elastisearch requests (helpful when
+                    your Elasticsearch instance sits behind a proxy)
+                    (default: '{"User-Agent": "elasticdump"}')
 --sourceOnly
                     Output only the json contained within the document _source
                     Normal: {"_index":"","_type":"","_id":"", "_source":{SOURCE}}

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -20,6 +20,7 @@ var defaults = {
   inputTransport: null,
   outputTransport: null,
   searchBody: null,
+  headers: null,
   sourceOnly: false,
   jsonLines: false,
   format: '',
@@ -35,20 +36,20 @@ var defaults = {
   transform: null,
   httpAuthFile: null
 }
-
+var jsonParsedOpts = ['searchBody', 'headers']
 var options = {}
 
+// parse passed options & use defaults otherwise
 for (var i in defaults) {
-  options[i] = defaults[i]
-  if (argv[i]) {
-    options[i] = argv[i]
-  }
+  options[i] = argv[i] || defaults[i]
+
   if (options[i] === 'true') { options[i] = true }
   if (options[i] === 'false') { options[i] = false }
-  // searchBody needs to go from JSON to object in order for size to be added later during elasticsearch query
-  if (i === 'searchBody') {
-    options[i] = JSON.parse(options[i])
-  }
+}
+
+// parse whitelisted json formatted options
+for (var i of jsonParsedOpts) {
+  if (options[i]) { options[i] = JSON.parse(options[i]) }
 }
 
 var log = function (type, message) {

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -37,8 +37,12 @@ var elasticdump = function (input, output, options) {
       self.inputType = 'file'
     }
 
+    var inputOpts = {
+      index: self.options['input-index'],
+      headers: self.options['headers']
+    }
     InputProto = require(path.join(__dirname, 'lib', 'transports', self.inputType))[self.inputType]
-    self.input = (new InputProto(self, self.options.input, self.options['input-index']))
+    self.input = (new InputProto(self, self.options.input, inputOpts))
   } else if (self.options.inputTransport) {
     self.inputType = String(self.options.inputTransport)
     InputProto = require(self.options.inputTransport)
@@ -58,8 +62,12 @@ var elasticdump = function (input, output, options) {
       if (self.options.output === '$') { self.options.toLog = false }
     }
 
+    var outputOpts = {
+      index: self.options['output-index'],
+      headers: self.options['headers']
+    }
     OutputProto = require(path.join(__dirname, 'lib', 'transports', self.outputType))[self.outputType]
-    self.output = (new OutputProto(self, self.options.output, self.options['output-index']))
+    self.output = (new OutputProto(self, self.options.output, outputOpts))
   } else if (self.options.outputTransport) {
     self.outputType = String(self.options.outputTransport)
     OutputProto = require(self.options.outputTransport)

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -3,15 +3,19 @@ var jsonParser = require('../jsonparser.js')
 var parseBaseURL = require('../parse-base-url')
 var aws4signer = require('../aws4signer')
 
-var elasticsearch = function (parent, url, index) {
-  this.base = parseBaseURL(url, index)
+var elasticsearch = function (parent, url, options) {
+  this.base = parseBaseURL(url, options.index)
   this.parent = parent
   this.lastScrollId = null
   this.totalSearchResults = 0
   this.elementsToSkip = 0
   this.searchBody = this.parent.options.searchBody
   this.ESversion = null
-  this.baseRequest = request.defaults({headers: { 'User-Agent': 'elasticdump' }})
+  this.baseRequest = request.defaults({
+    headers: Object.assign({
+      'User-Agent': 'elasticdump'
+    }, options.headers)
+  })
 }
 // accept callback
 // return (error, arr) where arr is an array of objects

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -3,7 +3,7 @@ var JSONStream = require('JSONStream')
 var fs = require('fs')
 var endOfLine = require('os').EOL
 
-var file = function (parent, file, options, direction) {
+var file = function (parent, file, options) {
   this.options = options
   this.parent = parent
   this.file = file

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -83,7 +83,7 @@ describe('parent child', function () {
     })
   })
 
-  after(function (done) { clear(done) })
+  after(clear)
 
   it('did the setup properly and parents + children are loaded', function (done) {
     var url = baseUrl + '/source_index/_search'

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -168,7 +168,7 @@ describe('parent child', function () {
       request.get(url, function (err, response, body) {
         should.not.exist(err)
         body = JSON.parse(body)
-        console.log(err, response, body);
+        console.log(err, response, body)
         // this confirms that there are no orphans too!
         body.hits.total.should.equal(cities.length + (cities.length * people.length))
         done()

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -168,6 +168,7 @@ describe('parent child', function () {
       request.get(url, function (err, response, body) {
         should.not.exist(err)
         body = JSON.parse(body)
+        console.log(err, response, body);
         // this confirms that there are no orphans too!
         body.hits.total.should.equal(cities.length + (cities.length * people.length))
         done()

--- a/test/test.js
+++ b/test/test.js
@@ -143,6 +143,28 @@ describe('ELASTICDUMP', function () {
     })
   })
 
+  it('sets custom headers', function (done) {
+    var Elasticsearch = require(path.join(__dirname, '../lib/transports', 'elasticsearch'))['elasticsearch']
+    this.timeout(testTimeout)
+    var parent = { options: { searchBody: 'none' } }
+    var opts = {
+      index: 'source_index',
+      headers: {
+        'User-Agent': 'testbot',
+        'Alt-Auth': 'SomeBearerToken',
+        'X-Something': 'anotherheader'
+      }
+    }
+    var es = (new Elasticsearch(parent, baseUrl, opts))
+    es.baseRequest(baseUrl, function (err, response, body) {
+      should.not.exist(err)
+      response.req._headers['user-agent'].should.equal('testbot')
+      response.req._headers['alt-auth'].should.equal('SomeBearerToken')
+      response.req._headers['x-something'].should.equal('anotherheader')
+      done()
+    })
+  })
+
   describe('es to es', function () {
     it('works for a whole index', function (done) {
       this.timeout(testTimeout)


### PR DESCRIPTION
Per GH issue #306 this PR adds the ability to set custom headers on ES requests.

Summary of changes:
- changed the signature of built-in transport constructors to take 3 args (the last one is an options object) -- note: changing this for externally `require`d transports would break them so that wasn't done
- simplified argument parsing logic & added the ability to whitelist an argument so it is automatically `JSON.parse()`d when passed
- removed a `direction` param which was never used in the file transport
- simplified a test clear callback
- added a test to make sure headers are set on requests and defaults can be overridden