### PR TITLE
removing extra console.log in test

### DIFF
--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -168,7 +168,6 @@ describe('parent child', function () {
       request.get(url, function (err, response, body) {
         should.not.exist(err)
         body = JSON.parse(body)
-        console.log(err, response, body)
         // this confirms that there are no orphans too!
         body.hits.total.should.equal(cities.length + (cities.length * people.length))
         done()


### PR DESCRIPTION
This was accidentally added to track down why Travis builds were failing on tests