### PR TITLE
Add "ignoreRouting" option for reindex scenario

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -13,6 +13,7 @@ var defaults = {
   type: 'data',
   delete: false,
   maxSockets: null,
+  ignoreRouting: false,
   input: null,
   'input-index': null,
   output: null,

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -368,7 +368,7 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
   if (data.length === 0) { return callback(null, 0) }
 
   var self = this
-  var extraFields = ['routing', 'parent', 'timestamp', 'ttl']
+  var extraFields = self.parent.options.ignoreRouting ? ['parent', 'timestamp', 'ttl'] : ['routing', 'parent', 'timestamp', 'ttl']
   var writes = 0
 
   var thisUrl = self.base.url + '/_bulk'


### PR DESCRIPTION
We are planning to use elasticdump to migrate some data around our cluster. However, the default setting for this tool was to carry over any custom routing. We moved that to be an optional addition.

Background:
For our use case (which follows the recommendations here: https://www.elastic.co/guide/en/elasticsearch/guide/2.x/user-based.html specifically: https://www.elastic.co/guide/en/elasticsearch/guide/2.x/one-big-user.html) we have a single large multi-tenant index with custom aliasing for each of our clients. This makes our index management simpler (since all clients share one index) but have data co-location through custom alias routing for our client's data. As is laid out in the docs, this is prone to data skew if a single client's data (located within a single shard) become too large, and so it is necessary to migrate abnormally large clients to their own custom index with default routing (spreading the skewed data across all nodes). By requiring that routing information was passed along with all re-indexed documents, we were unable to use this tool (since the goal is to re-index with default routing but after running elasticdump the skew was maintained).

This was my first stab at a quick fix (I'm not well versed in Node) which we used to unblock our preparations, but if you have style feedback or testing scenario suggestions I'm all ears!