### PR TITLE
Add sessionToken to defaults

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -34,6 +34,7 @@ var defaults = {
   awsSecretAccessKey: null,
   awsIniFileProfile: null,
   awsIniFileName: null,
+  sessionToken: null,
   transform: null,
   httpAuthFile: null
 }


### PR DESCRIPTION
Without it, it seems that passing the `--sessionToken` parameter on the command line does nothing, and authenticating with instance profile credentials is not possible, as `parent.options.sessionToken` is never set in [lib/aws4signer.js:30](https://github.com/taskrabbit/elasticsearch-dump/blob/0f14716c34e5a0088ac4f98ab0f3c33976f3b166/lib/aws4signer.js#L30).

Before change;
```
$ elasticdump \
    --input=https://foo.us-west-2.es.amazonaws.com/data \
    --output=/tmp/data.json \
    --type=data \
    --awsAccessKeyId 'FOO' \
    --awsSecretAccessKey 'BAR' \
    --sessionToken 'BAZ'
Tue, 23 May 2017 01:26:58 GMT | starting dump
Tue, 23 May 2017 01:27:00 GMT | Error Emitted => {"message":"The security token included in the request is invalid."}
Tue, 23 May 2017 01:27:00 GMT | Total Writes: 0
Tue, 23 May 2017 01:27:00 GMT | dump ended with error (get phase) => Error: {"message":"The security token included in the request is invalid."}
```

After change;
```
$ elasticdump \
    --input=https://foo.us-west-2.es.amazonaws.com/data \
    --output=/tmp/data.json \
    --type=data \
    --awsAccessKeyId 'FOO' \
    --awsSecretAccessKey 'BAR' \
    --sessionToken 'BAZ'
Tue, 23 May 2017 01:27:49 GMT | starting dump
Tue, 23 May 2017 01:27:52 GMT | got 100 objects from source elasticsearch (offset: 0)
Tue, 23 May 2017 01:27:52 GMT | sent 100 objects to destination file, wrote 100
Tue, 23 May 2017 01:27:53 GMT | got 100 objects from source elasticsearch (offset: 100)
Tue, 23 May 2017 01:27:53 GMT | sent 100 objects to destination file, wrote 100
```