### PR TITLE
[bug fix] add 'Content-Type': 'application/json' into header by default, for fi…

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -14,7 +14,8 @@ var elasticsearch = function (parent, url, options) {
   this.ESversion = null
   this.baseRequest = request.defaults({
     headers: Object.assign({
-      'User-Agent': 'elasticdump'
+      'User-Agent': 'elasticdump',
+      'Content-Type': 'application/json'
     }, options.headers)
   })
 }


### PR DESCRIPTION
…xing the warning message: [2017-10-17T11:30:33,587][WARN ][o.e.d.r.RestController   ] Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header. in Elasticsearch 5.5.2

<img width="1063" alt="warning" src="https://user-images.githubusercontent.com/1469585/31663054-5eafac66-b306-11e7-9371-cb2c01b027c6.png">

