### PR TITLE
Add size option to limit the total documents to move

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     How many objects to move in batch per operation
                     limit is approximate for file streams
                     (default: 100)
+                    
+--size							How many objects to retrieve
+										(default: -1 -> no limit)
+                    
 --debug
                     Display the elasticsearch commands being used
                     (default: false)

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -7,6 +7,7 @@ var packageData = require(path.join(__dirname, '..', 'package.json'))
 
 // For future developers.  If you add options here, be sure to add the option to test suite tests where necessary
 var defaults = {
+	size: -1,
   limit: 100,
   offset: 0,
   debug: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "2"
+
+services:
+
+  es_2:
+    image: elasticsearch:2.4
+    ports:
+    - 9200:9200
+
+  es_5:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.4
+    ports:
+    - 9200:9200
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - xpack.watcher.enabled=false
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+
+  es_6:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
+    ports:
+    - 9200:9200
+    environment:
+      - discovery.type=single-node

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -17,6 +17,11 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     How many objects to move in batch per operation
                     limit is approximate for file streams
                     (default: 100)
+
+--size
+                    How many objects to retrieve
+                    (default: -1 -> no limit)
+
 --debug
                     Display the elasticsearch commands being used
                     (default: false)

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -140,7 +140,7 @@ elasticsearch.prototype.getData = function (limit, offset, callback) {
       self.parent.options.scrollTime +
       '&from=' + offset
 
-    searchBody.size = limit
+    searchBody.size = self.parent.options.size >= 0 && self.parent.options.size < limit ? self.parent.options.size : limit
 
     searchRequest = {
       'uri': uri,
@@ -168,7 +168,7 @@ elasticsearch.prototype.getData = function (limit, offset, callback) {
         callback(err, [])
         return
       }
-      self.totalSearchResults = body.hits.total
+      self.totalSearchResults = self.parent.options.size >= 0 ? self.parent.options.size : body.hits.total
 
       scrollResultSet(self, callback, body.hits.hits)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -216,6 +216,32 @@ describe('ELASTICDUMP', function () {
       })
     })
 
+    it('can provide limit', function (done) {
+      this.timeout(testTimeout)
+      var options = {
+        limit: 100,
+        offset: 0,
+        debug: false,
+        type: 'data',
+        input: baseUrl + '/source_index/seeds',
+        output: baseUrl + '/destination_index',
+        size: 5,
+        scrollTime: '10m'
+      }
+
+      var dumper = new Elasticdump(options.input, options.output, options)
+
+      dumper.dump(function () {
+        var url = baseUrl + '/destination_index/_search'
+        request.get(url, function (err, response, body) {
+          should.not.exist(err)
+          body = JSON.parse(body)
+          body.hits.total.should.equal(5)
+          done()
+        })
+      })
+    })
+
     it('works for index/types', function (done) {
       this.timeout(testTimeout)
       var options = {


### PR DESCRIPTION
Limit the number of objects to move totally (not by shard).

Should fix:
- https://github.com/taskrabbit/elasticsearch-dump/issues/311
