### PR TITLE
es 6 support: add bulk right content type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ sudo: true
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
+  - "8"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ script: npm run test
 env:
   matrix:
     - "ES_VERSION=2.3.4 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.4/elasticsearch-2.3.4.deb"
-    - "ES_VERSION=5.0.2 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.0.2.deb"
+    - "ES_VERSION=5.6.4 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.deb"
+    - "ES_VERSION=6.0.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.deb"
 
 before_install:
   ## ES has different download locations for each version, so we'll download them both and then just use the one we want

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -14,7 +14,8 @@ var elasticsearch = function (parent, url, options) {
   this.ESversion = null
   this.baseRequest = request.defaults({
     headers: Object.assign({
-      'User-Agent': 'elasticdump'
+      'User-Agent': 'elasticdump',
+      'Content-Type': 'application/json'
     }, options.headers)
   })
 }

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -381,6 +381,10 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
     url: thisUrl,
     body: '',
     method: 'PUT',
+    headers: Object.assign({
+      'User-Agent': 'elasticdump',
+      'Content-Type': 'application/x-ndjson'
+    }, self.parent.options.headers),
     timeout: self.parent.options.timeout
   }
 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -529,7 +529,7 @@ function scrollResultSet (self, callback, loadedHits) {
     var scrollRequest = {
       'uri': self.base.host + '/_search' + '/scroll?scroll=' + self.parent.options.scrollTime,
       'method': 'GET',
-      'body': self.lastScrollId
+      'body': JSON.stringify({ scroll_id: self.lastScrollId })
     }
     aws4signer(scrollRequest, self.parent)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "elastic dump"
   ],
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "JSONStream": "^1.2.0",

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -8,7 +8,7 @@
 
 var path = require('path')
 var Elasticdump = require(path.join(__dirname, '..', 'elasticdump.js'))
-var request = require('request')
+
 var should = require('should')
 var fs = require('fs')
 var async = require('async')
@@ -21,6 +21,12 @@ var mapping = {
   city: {},
   person: { _parent: { type: 'city' } }
 }
+
+var request = require('request').defaults({
+  headers: {
+    'User-Agent': 'elasticdump',
+    'Content-Type': 'application/json'
+  }})
 
 var clear = function (callback) {
   var jobs = []
@@ -90,6 +96,7 @@ describe('parent child', function () {
     request.get(url, function (err, response, body) {
       should.not.exist(err)
       body = JSON.parse(body)
+
       // this confirms that there are no orphans too!
       body.hits.total.should.equal(cities.length + (cities.length * people.length))
       done()

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,6 @@ http.globalAgent.maxSockets = 10
 
 var path = require('path')
 var Elasticdump = require(path.join(__dirname, '..', 'elasticdump.js'))
-var request = require('request')
 var should = require('should')
 var fs = require('fs')
 var os = require('os')
@@ -20,6 +19,12 @@ while (i < seedSize) {
   seeds[i] = { key: ('key' + i) }
   i++
 }
+
+var request = require('request').defaults({
+  headers: {
+    'User-Agent': 'elasticdump',
+    'Content-Type': 'application/json'
+  }})
 
 var seed = function (index, type, settings, callback) {
   var payload = {url: baseUrl + '/' + index, body: JSON.stringify(settings)}


### PR DESCRIPTION
According https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html:

> NOTE: the final line of data must end with a newline character \n. Each newline character may be preceded by a carriage return \r. When sending requests to this endpoint the Content-Type header should be set to application/x-ndjson.

Should fix:

- #357
- #350