### PR TITLE
Support scroll-requests on AWS ElasticSearch

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -575,8 +575,12 @@ function scrollResultSet (self, callback, loadedHits, response) {
     }
   } else {
     var scrollRequest = {
-      'uri': self.base.host + '/_search' + '/scroll?scroll=' + self.parent.options.scrollTime + '&scroll_id=' + self.lastScrollId,
-      'method': 'GET'
+      'uri': self.base.host + '/_search' + '/scroll',
+      'method': 'POST',
+      'body': JSON.stringify({
+        'scroll': self.parent.options.scrollTime,
+        'scroll_id': self.lastScrollId
+      })
     }
     aws4signer(scrollRequest, self.parent)
 


### PR DESCRIPTION
> To avoid a problem with = characters in scroll_id values, use the
> request body, not the query string, to pass scroll_id values to Amazon
> ES.
> ([Source](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-es-operations.html))

This change utilizes a [`POST` request](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search-request-scroll.html) to ensure the `scroll_id` is submitted properly on AWS and the scroll request will not fail with `{"message":null}`.