### PR TITLE
added support for index name prefix & suffix for multi-elasticdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ The limited option set includes:
 - `offset`:     `0`,
 - `direction`:   `dump`,
 - `ignoreType`:   ``
+- `prefix`:   `'''`
+- `suffix`:   `''`
 - `interval`:     `1000`  
 
 If the `--direction` is `dump`, which is the default, `--input` MUST be a URL for the base location of an ElasticSearch server (i.e. `http://localhost:9200`) and `--output` MUST be a directory. Each index that does match will have a data, mapping, and analyzer file created.
@@ -360,8 +362,11 @@ For loading files that you have dumped from multi-elasticsearch, `--direction` s
 
 `--parallel` is how many forks should be run simultaneously and `--match` is used to filter which indexes should be dumped/loaded (regex).
 
-New options, `--ignoreType` allows a type to be ignored from the dump/load. Three options are supported. `data,mapping,analyzer`. Multi-type support is available, when used each type must be comma(,)-separated
+`--ignoreType` allows a type to be ignored from the dump/load. Three options are supported. `data,mapping,analyzer`. Multi-type support is available, when used each type must be comma(,)-separated
 and `interval` allows control over the interval for spawning a dump/load for a new index. For small indices this can be set to `0` to reduce delays and optimize performance
+
+New options, `--suffix` allows you to add a suffix to the index name being created e.g. `es6-${index}` and
+`--prefix` allows you to add a prefix to the index name e.g. `$index}-backup-2018-03-13`
 
 ## Module Transform
 

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -39,6 +39,8 @@ var defaults = {
   transform: null,
   httpAuthFile: null,
   params: null,
+  prefix : '',
+  suffix : ''
 }
 var jsonParsedOpts = ['searchBody', 'headers', 'params']
 var options = {}

--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -42,7 +42,9 @@ var defaults = {
   ignoreData:false,
   ignoreMapping: false,
   ignoreType: [],
-  interval : 1000
+  interval : 1000,
+  prefix : '',
+  suffix : ''
 }
 
 for (var i in defaults) {
@@ -306,7 +308,9 @@ var load = function () {
       '--output=' + output,
       '--scrollTime=' + options.scrollTime,
       '--limit=' + options.limit,
-      '--offset=' + options.offset
+      '--offset=' + options.offset,
+      '--prefix=' + options.prefix,
+      '--suffix=' + options.suffix
     ])
 
     dataChild.on('close', function (code) {

--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -16,7 +16,9 @@ var getIo = function (elasticdump, type) {
 
     var inputOpts = {
       index: elasticdump.options[ type + '-index' ],
-      headers: elasticdump.options[ 'headers' ]
+      headers: elasticdump.options[ 'headers' ],
+      prefix: elasticdump.options['prefix'],
+      suffix: elasticdump.options['suffix']
     }
     EntryProto = require(path.join(__dirname, 'transports', elasticdump[ type + 'Type' ]))[elasticdump[ type + 'Type' ]]
     elasticdump[type] = (new EntryProto(elasticdump, elasticdump.options[type], inputOpts))

--- a/lib/parse-base-url.js
+++ b/lib/parse-base-url.js
@@ -1,11 +1,13 @@
-function parseBaseURL (_url, _index) {
+var _ = require('lodash')
+
+function parseBaseURL (_url, options) {
   var host = _url.replace(/\/+$/, '')
   var hostParts = host.split('/')
-  var indexParts = (_index || '').split('/').filter(Boolean)
+  var indexParts = (_.get(options, 'index', '') || '').split('/').filter(Boolean)
   var index
   var type
 
-  if (typeof _index === 'string') {
+  if (typeof _.get(options, 'index') === 'string') {
     index = indexParts[0]
     type = indexParts[1]
   } else if (hostParts.length <= 3) {
@@ -17,6 +19,14 @@ function parseBaseURL (_url, _index) {
   } else {
     host = hostParts.slice(0, -1).join('/')
     index = hostParts[hostParts.length - 1]
+  }
+
+  if (_.has(options, 'prefix')) {
+    index = options.prefix + index
+  }
+
+  if (_.has(options, 'suffix')) {
+    index += options.suffix
   }
 
   return {

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -6,7 +6,7 @@ var async = require('async')
 var _ = require('lodash')
 
 var elasticsearch = function (parent, url, options) {
-  this.base = parseBaseURL(url, options.index)
+  this.base = parseBaseURL(url, options)
   this.parent = parent
   this.lastScrollId = null
   this.settingsExclude = ['settings.index.version', 'settings.index.creation_date', 'settings.index.uuid', 'settings.index.provided_name']

--- a/test/parse-base-url.tests.js
+++ b/test/parse-base-url.tests.js
@@ -39,7 +39,7 @@ describe('parseBaseURL', function () {
   })
 
   it('should parse index and type from index', function () {
-    parseBaseURL('http://localhost:9200/proxied/host', 'index/type').should.eql({
+    parseBaseURL('http://localhost:9200/proxied/host', {index: 'index/type'}).should.eql({
       url: 'http://localhost:9200/proxied/host/index/type',
       host: 'http://localhost:9200/proxied/host',
       index: 'index',
@@ -48,7 +48,7 @@ describe('parseBaseURL', function () {
   })
 
   it('should parse index from index', function () {
-    parseBaseURL('http://localhost:9200/proxied/host', 'index').should.eql({
+    parseBaseURL('http://localhost:9200/proxied/host', {index: 'index'}).should.eql({
       url: 'http://localhost:9200/proxied/host/index',
       host: 'http://localhost:9200/proxied/host',
       index: 'index',
@@ -57,7 +57,7 @@ describe('parseBaseURL', function () {
   })
 
   it('should parse index and type from index with leading and trailing slashes', function () {
-    parseBaseURL('http://localhost:9200/proxied/host', '/index/type/').should.eql({
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/index/type/'}).should.eql({
       url: 'http://localhost:9200/proxied/host/index/type',
       host: 'http://localhost:9200/proxied/host',
       index: 'index',
@@ -66,7 +66,7 @@ describe('parseBaseURL', function () {
   })
 
   it('should parse index from index with leading slash', function () {
-    parseBaseURL('http://localhost:9200/proxied/host', '/index').should.eql({
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/index'}).should.eql({
       url: 'http://localhost:9200/proxied/host/index',
       host: 'http://localhost:9200/proxied/host',
       index: 'index',
@@ -75,11 +75,38 @@ describe('parseBaseURL', function () {
   })
 
   it('should accept an empty index parameter to mean url is host', function () {
-    parseBaseURL('http://localhost:9200/proxied/host', '/').should.eql({
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/'}).should.eql({
       url: 'http://localhost:9200/proxied/host',
       host: 'http://localhost:9200/proxied/host',
       index: undefined,
       type: undefined
+    })
+  })
+
+  it('should include prefix', function () {
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/index/type/', prefix: 'es6-'}).should.eql({
+      url: 'http://localhost:9200/proxied/host/es6-index/type',
+      host: 'http://localhost:9200/proxied/host',
+      index: 'es6-index',
+      type: 'type'
+    })
+  })
+
+  it('should include suffix', function () {
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/index/type/', suffix: '.backup'}).should.eql({
+      url: 'http://localhost:9200/proxied/host/index.backup/type',
+      host: 'http://localhost:9200/proxied/host',
+      index: 'index.backup',
+      type: 'type'
+    })
+  })
+
+  it('should include prefix & suffix', function () {
+    parseBaseURL('http://localhost:9200/proxied/host', {index: '/index/type/', prefix: 'es6-', suffix: '.backup'}).should.eql({
+      url: 'http://localhost:9200/proxied/host/es6-index.backup/type',
+      host: 'http://localhost:9200/proxied/host',
+      index: 'es6-index.backup',
+      type: 'type'
     })
   })
 })


### PR DESCRIPTION
Use case for this. 

backing up indices during a migration, but want to suffix index with the date e.g. products **.backup-2018-03-13**

or prefixing index names to denote a new type of data or es version.

es6-products
es5-products
es7-products