### PR TITLE
fixed an issue that caused delete to fail due to wild-card.

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -496,7 +496,7 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
 
 elasticsearch.prototype.del = function (elem, callback) {
   var self = this
-  var thisUrl = self.base.url + '/' + encodeURIComponent(elem._type) + '/' + encodeURIComponent(elem._id)
+  var thisUrl = self.base.host + '/' + encodeURIComponent(elem._index) + '/' + encodeURIComponent(elem._type) + '/' + encodeURIComponent(elem._id)
 
   self.parent.emit('debug', 'deleteUrl: ' + thisUrl)
   var esRequest = {


### PR DESCRIPTION
When `--delete` is used a wildcard, the delete silently fails due to
index being multi (*). Now the index of the current item is used
to perform deletes.

fixes  #423