### PR TITLE
use the index defined in the input if there is none defined in the url.

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -439,11 +439,11 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
 
   data.forEach(function (elem) {
     var actionMeta = { index: {} }
-    // use type from base otherwise fallback to elem
 
-    if (!self.base.index) {
-      actionMeta.index._index = elem._index
-    }
+    // use index from base otherwise fallback to elem
+    actionMeta.index._index = self.base.index || elem._index
+
+    // use type from base otherwise fallback to elem
     actionMeta.index._type = self.base.type || elem._type
     actionMeta.index._id = elem._id
 

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -440,6 +440,10 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
   data.forEach(function (elem) {
     var actionMeta = { index: {} }
     // use type from base otherwise fallback to elem
+
+    if (!self.base.index) {
+      actionMeta.index._index = elem._index
+    }
     actionMeta.index._type = self.base.type || elem._type
     actionMeta.index._id = elem._id
 


### PR DESCRIPTION
fixes #425