### PR TITLE
fixes scrolling on aws-es

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -669,7 +669,10 @@ function scrollResultSet (self, callback, loadedHits, response) {
 
     if (awsChain || awsAccessKeyId || awsIniFileProfile) {
       Object.assign(scrollRequest, {
-        'uri': scrollRequest.uri + '?scroll=' + self.parent.options.scrollTime + '&scroll_id=' + self.lastScrollId,
+        'uri': scrollRequest.uri + '?scroll=' + self.parent.options.scrollTime,
+        'body': JSON.stringify({
+          scroll_id: self.lastScrollId
+        }),
         'method': 'GET'
       })
     } else if (self.ESversion === '1') {


### PR DESCRIPTION
Fixed as [AWS doc](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-supported-es-operations.html#es_version_5_5) suggests: moving scroll_id to the request body.