### PR TITLE
Revert "resolves an issue that causes a race condition"

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -91,9 +91,7 @@ if (argv.help === true) {
 
   dumper.dump(function (error) {
     if (error) {
-      return () => process.exit(1)
-    } else {
-      return () => {}
+      process.exit(1)
     }
   })
 }

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -140,21 +140,21 @@ elasticdump.prototype.dump = function (callback, continuing, limit, offset, tota
           }
 
           if (data.length > 0 && toContinue) {
-            return self.dump(callback, true, limit, offset, totalWrites)
+            self.dump(callback, true, limit, offset, totalWrites)
           } else if (toContinue) {
             self.log('Total Writes: ' + totalWrites)
             self.log('dump complete')
-            if (typeof callback === 'function') { return callback(null, totalWrites) }
+            if (typeof callback === 'function') { callback(null, totalWrites) }
           } else if (toContinue === false) {
             self.log('Total Writes: ' + totalWrites)
             self.log('dump ended with error (set phase)  => ' + String(err))
-            if (typeof callback === 'function') { return callback(err, totalWrites) }
+            if (typeof callback === 'function') { callback(err, totalWrites) }
           }
         })
       } else {
         self.log('Total Writes: ' + totalWrites)
         self.log('dump ended with error (get phase) => ' + String(err))
-        if (typeof callback === 'function') { return callback(err, totalWrites) }
+        if (typeof callback === 'function') { callback(err, totalWrites) }
       }
     })
   }

--- a/elasticdump.js
+++ b/elasticdump.js
@@ -140,21 +140,21 @@ elasticdump.prototype.dump = function (callback, continuing, limit, offset, tota
           }
 
           if (data.length > 0 && toContinue) {
-            self.dump(callback, true, limit, offset, totalWrites)
+            return self.dump(callback, true, limit, offset, totalWrites)
           } else if (toContinue) {
             self.log('Total Writes: ' + totalWrites)
             self.log('dump complete')
-            if (typeof callback === 'function') { callback(null, totalWrites) }
+            if (typeof callback === 'function') { return callback(null, totalWrites) }
           } else if (toContinue === false) {
             self.log('Total Writes: ' + totalWrites)
             self.log('dump ended with error (set phase)  => ' + String(err))
-            if (typeof callback === 'function') { callback(err, totalWrites) }
+            if (typeof callback === 'function') { return callback(err, totalWrites) }
           }
         })
       } else {
         self.log('Total Writes: ' + totalWrites)
         self.log('dump ended with error (get phase) => ' + String(err))
-        if (typeof callback === 'function') { callback(err, totalWrites) }
+        if (typeof callback === 'function') { return callback(err, totalWrites) }
       }
     })
   }

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -116,7 +116,7 @@ file.prototype.set = function (data, limit, offset, callback) {
 
   if (data.length === 0) {
     if (self.file === '$') {
-      process.nextTick(callback(null, self.lineCounter))
+      process.nextTick(() => callback(null, self.lineCounter))
     } else {
       self.stream.on('close', function () {
         delete self.stream

--- a/lib/transports/file.js
+++ b/lib/transports/file.js
@@ -143,9 +143,7 @@ file.prototype.set = function (data, limit, offset, callback) {
       self.lineCounter++
     })
 
-    process.nextTick(function () {
-      callback(error, self.lineCounter)
-    })
+    process.nextTick(() => callback(error, self.lineCounter))
   }
 }
 

--- a/test/parentchild.js
+++ b/test/parentchild.js
@@ -280,8 +280,8 @@ describex('parent child', function () {
       dataLines.forEach(function (d) {
         if (d._type === 'person') {
           var parent
-          if (d._parent) { parent = d._parent }  // ES 2.x
-          if (d.fields && d.fields._parent) { parent = d.fields._parent }  // ES 1.x
+          if (d._parent) { parent = d._parent } // ES 2.x
+          if (d.fields && d.fields._parent) { parent = d.fields._parent } // ES 1.x
           should.exist(parent)
           dumpedPeople.push(d)
         }

--- a/test/transform.js
+++ b/test/transform.js
@@ -141,9 +141,9 @@ describe('external transform module should be executed for written documents', f
       body.hits.hits.forEach(function (doc) {
         doc._source.bar.should.equal(
           crypto
-              .createHash('md5')
-              .update(String(doc._source.foo))
-              .digest('hex')
+            .createHash('md5')
+            .update(String(doc._source.foo))
+            .digest('hex')
         )
       })
       done()


### PR DESCRIPTION
Fixes #436 

This reverts commit 992b8012c4b0734388c6487c556f54d6151a8bea by partially
undoing some (but not all) of the changes made by that commit.

The problem this reversion addresses is that, as of 3.3.8, elasticdump no longer sets a
non-zero status code when a failure occrrs during the dump phase.


Specifically:

elasticdump --input https://nonentity.example/temp --output /tmp/temp.json
echo $?

reports 0 when it should report 1.

The apparent reason for this is that the callback passed in the mainline now returns
a function that calls process.exit(1) instead of performing the call itself.

Since no other changes were made to ensure that the function returned by the
call was actually called process.exit(1) was never called, meaning that
elasticdump could fail failed silently (at least as far as the exit code was concerned).

One part of the original change has been left as is, since it seemed sound, specifically:

https://github.com/taskrabbit/elasticsearch-dump/commit/992b8012c4b0734388c6487c556f54d6151a8bea#diff-f60b04ac83f174b93b06625be32a86f5

Signed-off-by: Jon Seymour <jon@wildducktheories.com>