### PR TITLE
Allow special characters to be imported to ES

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -162,7 +162,7 @@ var dump = function () {
 
   indexCounter++
 
-  var input = options.input + '/' + encodeURIComponent(index)
+  var input = options.input + '/' + encodeURIComponent(index).toLowerCase()
   var outputData = options.output + '/' + index + '.json'
   var outputMapping = options.output + '/' + index + '.mapping.json'
   var outputAnalyzer = options.output + '/' + index + '.analyzer.json'
@@ -253,7 +253,7 @@ var load = function () {
 
   indexCounter++
 
-  var output = options.output + '/' + encodeURIComponent(index)
+  var output = options.output + '/' + encodeURIComponent(index).toLowerCase()
   var inputData = options.input + '/' + index + '.json'
   var inputMapping = options.input + '/' + index + '.mapping.json'
   var inputAnalyzer = options.input + '/' + index + '.analyzer.json'


### PR DESCRIPTION
If the name of your index contains special characters such as ':', the encodeURIComponent will transforms it to the string '%3A'.
Elasticsearch refuses to create indexes (https://www.elastic.co/guide/en/elasticsearch/guide/current/_document_metadata.html#_index) that have upper cases leading to not being able to import the dump.

This PR aims to fix this behaviour by transforming all hexa characters to lowercase and being able to import a whole dump with custom special characters