### PR TITLE
include version info in bulk indexing

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -557,7 +557,7 @@ elasticsearch.prototype.setData = function (data, limit, offset, callback) {
   if (data.length === 0) { return callback(null, 0) }
 
   var self = this
-  var extraFields = ['routing', 'parent', 'timestamp', 'ttl']
+  var extraFields = ['routing', 'parent', 'timestamp', 'ttl', 'version', 'version_type']
   var writes = 0
 
   var thisUrl = self.base.url + '/_bulk'


### PR DESCRIPTION
Currently, any potential `_version` or `_version_type` field were not included in the _bulk indexing action meta, effectively not importing the documents in the exact state as they were dumped. This PR adds the field along the other document meta fields (i.e. `ttl`, `routing`, etc.).

_PS: Let me know if I should add any extra tests, though I didn't find anything related for fields like e.g. `ttl`. I can also add a small example on how to dump documents with the `_version` field and then import them by picking a `version_type` through using the `--transform` option._