### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ elasticdump \
 elasticdump \
   --input=http://production.es.com:9200/my_index \
   --output=query.json \
-  --searchBody '{"query":{"term":{"username": "admin"}}}'
+  --searchBody='{"query":{"term":{"username": "admin"}}}'
 
 # Copy a single shard data:
 elasticdump \


### PR DESCRIPTION
Adding the equal sign for consistency. It does work without. I think this leaves the user less confused - wondering whether there was a typo - when dealing with other errors on the cmd maybe?