### PR TITLE
PR for #491 Allow TLS X509 client authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,19 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --s3RecordKey
                     Object key (filename) for the data to be uploaded
                                                           
+--cert, --input-cert, --output-cert
+                    Client certificate file. Use --cert if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--key, --input-key, --output-key
+                    Private key file. Use --key if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--pass, --input-pass, --output-pass
+                    Pass phrase for the private key. Use --pass if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--ca, --input-ca, --output-ca
+                    CA certificate. Use --ca if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+
 --help
                     This page
 ```

--- a/README.md
+++ b/README.md
@@ -389,8 +389,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --s3Bucket
                     Name of the bucket to which the data will be uploaded
 --s3RecordKey
-                    Object key (filename) for the data to be uploaded
-                                                          
+                    Object key (filename) for the data to be uploaded 
+--tlsAuth
+                    Enable TLS X509 client authentication
 --cert, --input-cert, --output-cert
                     Client certificate file. Use --cert if source and destination are identical.
                     Otherwise, use the one prefixed with --input or --output as needed.

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -52,7 +52,11 @@ var defaults = {
   retryAttempts: 0,
   retryDelay: 5000,
   parseExtraFields: '',
-  fileSize: -1
+  fileSize: -1,
+  cert: null,
+  key: null,
+  passphrase: null,
+  ca: null
 }
 var jsonParsedOpts = ['searchBody', 'headers', 'params']
 var options = {}

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -57,6 +57,7 @@ var defaults = {
   key: null,
   pass: null,
   ca: null,
+  tlsAuth: false,
   'input-cert': null,
   'input-key': null,
   'input-pass': null,

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -55,8 +55,16 @@ var defaults = {
   fileSize: -1,
   cert: null,
   key: null,
-  passphrase: null,
-  ca: null
+  pass: null,
+  ca: null,
+  'input-cert': null,
+  'input-key': null,
+  'input-pass': null,
+  'input-ca': null,
+  'output-cert': null,
+  'output-key': null,
+  'output-pass': null,
+  'output-ca': null
 }
 var jsonParsedOpts = ['searchBody', 'headers', 'params']
 var options = {}

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -168,6 +168,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Name of the bucket to which the data will be uploaded
 --s3RecordKey
                     Object key (filename) for the data to be uploaded
+--tlsAuth
+                    Enable TLS X509 client authentication
 --cert, --input-cert, --output-cert
                     Client certificate file. Use --cert if source and destination are identical.
                     Otherwise, use the one prefixed with --input or --output as needed.

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -168,6 +168,18 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     Name of the bucket to which the data will be uploaded
 --s3RecordKey
                     Object key (filename) for the data to be uploaded
+--cert, --input-cert, --output-cert
+                    Client certificate file. Use --cert if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--key, --input-key, --output-key
+                    Private key file. Use --key if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--pass, --input-pass, --output-pass
+                    Pass phrase for the private key. Use --pass if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
+--ca, --input-ca, --output-ca
+                    CA certificate. Use --ca if source and destination are identical.
+                    Otherwise, use the one prefixed with --input or --output as needed.
 --help
                     This page
 

--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -19,7 +19,8 @@ const getIo = (elasticdump, type) => {
 
     const inputOpts = {
       index: elasticdump.options[`${type}-index`],
-      headers: elasticdump.options['headers']
+      headers: elasticdump.options['headers'],
+      type: type
     }
 
     if (type === 'output') {

--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -20,7 +20,7 @@ const getIo = (elasticdump, type) => {
     const inputOpts = {
       index: elasticdump.options[`${type}-index`],
       headers: elasticdump.options['headers'],
-      type: type
+      type
     }
 
     if (type === 'output') {

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -32,19 +32,36 @@ class elasticsearch {
       maxAttempts: this.parent.options.retryAttempts || 5, // (default) try 5 times
       retryDelay: this.parent.options.retryDelay || 5000, // (default) wait for 5s before trying again
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
-    };
+    }
 
-    ['cert', 'key', 'passphrase', 'ca'].forEach(sslOption => {
-      if (parent.options[sslOption]) {
-        if (sslOption === 'passphrase') {
-          defaultOptions[sslOption] = parent.options[sslOption]
+    if (options.type === 'input') {
+      Object.assign(defaultOptions,
+        this.applySSL(['input-cert', 'input-key', 'input-pass', 'input-ca']))
+    } else {
+      Object.assign(defaultOptions,
+        this.applySSL(['output-cert', 'output-key', 'output-pass', 'output-ca']))
+    }
+
+    Object.assign(defaultOptions, this.applySSL(['cert', 'key', 'pass', 'ca']))
+
+    this.baseRequest = request.defaults(defaultOptions)
+  }
+
+  applySSL (props) {
+    const options = {}
+    const parent = this.parent
+    props.forEach(prop => {
+      const val = parent.options[prop]
+      if (val) {
+        const newProp = prop.replace(/^input-/, '').replace(/^output-/, '')
+        if (newProp === 'pass') {
+          options['passphrase'] = val
         } else {
-          defaultOptions[sslOption] = fs.readFileSync(parent.options[sslOption])
+          options[newProp] = fs.readFileSync(val)
         }
       }
     })
-
-    this.baseRequest = request.defaults(defaultOptions)
+    return options
   }
 
   // accept callback

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -5,6 +5,7 @@ const aws4signer = require('../aws4signer')
 const async = require('async')
 const _ = require('lodash')
 const {parseMetaFields} = require('../parse-meta-data')
+const fs = require('fs')
 
 class elasticsearch {
   constructor (parent, url, options) {
@@ -21,7 +22,8 @@ class elasticsearch {
     this.elementsToSkip = 0
     this.searchBody = this.parent.options.searchBody
     this.ESversion = null
-    this.baseRequest = request.defaults({
+
+    const defaultOptions = {
       timeout: this.parent.options.timeout,
       headers: Object.assign({
         'User-Agent': 'elasticdump',
@@ -30,7 +32,19 @@ class elasticsearch {
       maxAttempts: this.parent.options.retryAttempts || 5, // (default) try 5 times
       retryDelay: this.parent.options.retryDelay || 5000, // (default) wait for 5s before trying again
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
+    };
+
+    ['cert', 'key', 'passphrase', 'ca'].forEach(sslOption => {
+      if (parent.options[sslOption]) {
+        if (sslOption === 'passphrase') {
+          defaultOptions[sslOption] = parent.options[sslOption]
+        } else {
+          defaultOptions[sslOption] = fs.readFileSync(parent.options[sslOption])
+        }
+      }
     })
+
+    this.baseRequest = request.defaults(defaultOptions)
   }
 
   // accept callback

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -34,15 +34,19 @@ class elasticsearch {
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
     }
 
-    if (options.type === 'input') {
-      Object.assign(defaultOptions,
-        this.applySSL(['input-cert', 'input-key', 'input-pass', 'input-ca']))
-    } else {
-      Object.assign(defaultOptions,
-        this.applySSL(['output-cert', 'output-key', 'output-pass', 'output-ca']))
+    if (this.parent.options.tlsAuth) {
+      switch (options.type) {
+        case 'input':
+          Object.assign(defaultOptions,
+            this.applySSL(['input-cert', 'input-key', 'input-pass', 'input-ca']))
+          break
+        default:
+          Object.assign(defaultOptions,
+            this.applySSL(['output-cert', 'output-key', 'output-pass', 'output-ca']))
+          break
+      }
+      Object.assign(defaultOptions, this.applySSL(['cert', 'key', 'pass', 'ca']))
     }
-
-    Object.assign(defaultOptions, this.applySSL(['cert', 'key', 'pass', 'ca']))
 
     this.baseRequest = request.defaults(defaultOptions)
   }


### PR DESCRIPTION
Just a draft version to see if that's ok to go forward. It's been tested locally. To use it, add ssl options as command line arguments when launch elasticdump, e.g. --cert, --key,  --ca, etc. Then, the tool will pick up the cert and key files when exist.