### PR TITLE
Add s3Region option to fix China Region S3 upload issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     AWS access key ID
 --s3SecretAccessKey
                     AWS secret access key
+--s3Region
+                    AWS region
 --s3Bucket
                     Name of the bucket to which the data will be uploaded
 --s3RecordKey

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -40,6 +40,7 @@ var defaults = {
   awsIniFileProfile: null,
   s3AccessKeyId: null,
   s3SecretAccessKey: null,
+  s3Region: null,
   s3Bucket: null,
   s3RecordKey: null,
   awsIniFileName: null,

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -164,6 +164,8 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     AWS access key ID
 --s3SecretAccessKey
                     AWS secret access key
+--s3Region          
+                    AWS region
 --s3Bucket
                     Name of the bucket to which the data will be uploaded
 --s3RecordKey

--- a/lib/transports/s3.js
+++ b/lib/transports/s3.js
@@ -2,7 +2,7 @@ const util = require('util')
 const endOfLine = require('os').EOL
 const jsonParser = require('../jsonparser.js')
 const UploadStream = require('s3-stream-upload')
-const S3 = require('aws-sdk').S3
+const AWS = require('aws-sdk')
 const {Readable} = require('stream')
 
 class s3 {
@@ -13,10 +13,17 @@ class s3 {
     this.lineCounter = 0
     this.stream = null
     this.elementsToSkip = 0
-    this._s3 = new S3({
+
+    AWS.config.update({
       accessKeyId: parent.options.s3AccessKeyId,
       secretAccessKey: parent.options.s3SecretAccessKey
     })
+    if (parent.options.s3Region != null) {
+      AWS.config.update({
+        region: parent.options.s3Region
+      })
+    }
+    this._s3 = new AWS.S3()
     this._reading = false
   }
 


### PR DESCRIPTION
Hi there, 

I'm trying to add ` --s3Region` option to fix #509  issue. 

A little background about AWS China Region, there is 2 Regions (cn-north-1, cn-northwest-1) till now (2019-01-12). China Region is a little bit different from AWS Global, so I suggest we better add `--s3Region` to make upload ES data to AWS S3 China Region possible. 

I've tested this in AWS China Region,  hope that will help.  
```
 ./bin/elasticdump --input=http://10.100.17.87:9200/kubernetes-agentpns-2019.01.01 --type=data --s3Bucket "nginx-logs" --s3AccessKeyId "my-access-id" --s3SecretAccessKey "my-access-key" --s3RecordKey "nginx-json-2019.01.08"  --s3Region "cn-north-1"
```
![image](https://user-images.githubusercontent.com/785405/51069221-86c3d600-1665-11e9-97ef-bb861679a01e.png)

