### PR TITLE
Add socks proxy options

### DIFF
--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -66,7 +66,11 @@ const defaults = {
   'output-cert': null,
   'output-key': null,
   'output-pass': null,
-  'output-ca': null
+  'output-ca': null,
+  inputSocksProxy: null,
+  inputSocksPort: null,
+  outputSocksProxy: null,
+  outputSocksPort: null
 }
 const jsonParsedOpts = ['searchBody', 'headers', 'params']
 const options = {}

--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -6,6 +6,8 @@ const async = require('async')
 const _ = require('lodash')
 const {parseMetaFields} = require('../parse-meta-data')
 const fs = require('fs')
+const agent = require('socks5-http-client/lib/Agent')
+const sslAgent = require('socks5-https-client/lib/Agent')
 
 class elasticsearch {
   constructor (parent, url, options) {
@@ -34,6 +36,16 @@ class elasticsearch {
       retryStrategy: request.RetryStrategies.HTTPOrNetworkError // (default) retry on 5xx or network errors
     }
 
+    if (parent.options.inputSocksProxy && options.type == 'input') {
+        Object.assign(defaultOptions,
+          this.applyProxy(url, parent.options.inputSocksProxy, parent.options.inputSocksPort))
+    }
+
+    if (parent.options.outputSocksProxy && options.type == 'output') {
+        Object.assign(defaultOptions,
+          this.applyProxy(url, parent.options.outputSocksProxy, parent.options.outputSocksPort))
+    }
+
     if (this.parent.options.tlsAuth) {
       switch (options.type) {
         case 'input':
@@ -49,6 +61,22 @@ class elasticsearch {
     }
 
     this.baseRequest = request.defaults(defaultOptions)
+  }
+
+  applyProxy (url, proxyHost, proxyPort) {
+    let reqAgent = agent
+
+    if (url.substring(0, 5).toLowerCase() === 'https') {
+      reqAgent = sslAgent
+    }
+
+    return {
+      agentClass: reqAgent,
+      agentOptions: {
+        socksHost: proxyHost,
+        socksPort: proxyPort
+      }
+    }
   }
 
   applySSL (props) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "optimist": "latest",
     "request": "2.x.x",
     "requestretry": "^3.0.1",
-    "s3-stream-upload": "2.0.2"
+    "s3-stream-upload": "2.0.2",
+    "socks5-http-client": "^1.0.4",
+    "socks5-https-client": "^1.2.1"
   },
   "devDependencies": {
     "mocha": "latest",


### PR DESCRIPTION
Adds options to route traffic through a SOCKS proxy:

- `inputSocksProxy`: defines the proxy host for input transport
- `inputSocksPort`: defines the proxy port for input transport
- `outputSocksProxy`: defines the proxy host for input transport
- `outputSocksPort`: defines the proxy port for input transport