### PR TITLE
add support for import from s3

### DIFF
--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -1,18 +1,18 @@
 const isUrl = require('./is-url')
 const addAuth = require('./add-auth')
 const path = require('path')
+const s3urls = require('s3urls')
 
 const getIo = (elasticdump, type) => {
   let EntryProto
-  let isS3
-  if ((elasticdump.options[type] && !elasticdump.options[`${type}Transport`]) || (isS3 = !!(type === 'output' && elasticdump.options.s3Bucket))) {
-    if (isS3) {
-      elasticdump[`${type}Type`] = 's3'
-    } else if (isUrl(elasticdump.options[type])) {
+  if (elasticdump.options[type] && !elasticdump.options[`${type}Transport`]) {
+    if (isUrl(elasticdump.options[type])) {
       elasticdump[`${type}Type`] = 'elasticsearch'
       if (elasticdump.options.httpAuthFile) {
         elasticdump.options[type] = addAuth(elasticdump.options[type], elasticdump.options.httpAuthFile)
       }
+    } else if (s3urls.valid(elasticdump.options[type])) {
+      elasticdump[`${type}Type`] = 's3'
     } else {
       elasticdump[`${type}Type`] = 'file'
     }

--- a/lib/ioHelper.js
+++ b/lib/ioHelper.js
@@ -5,13 +5,14 @@ const s3urls = require('s3urls')
 
 const getIo = (elasticdump, type) => {
   let EntryProto
-  if (elasticdump.options[type] && !elasticdump.options[`${type}Transport`]) {
+  let isS3
+  if ((elasticdump.options[type] && !elasticdump.options[`${type}Transport`]) || (isS3 = !!(type === 'output' && elasticdump.options.s3Bucket))) {
     if (isUrl(elasticdump.options[type])) {
       elasticdump[`${type}Type`] = 'elasticsearch'
       if (elasticdump.options.httpAuthFile) {
         elasticdump.options[type] = addAuth(elasticdump.options[type], elasticdump.options.httpAuthFile)
       }
-    } else if (s3urls.valid(elasticdump.options[type])) {
+    } else if (isS3 || s3urls.valid(elasticdump.options[type])) {
       elasticdump[`${type}Type`] = 's3'
     } else {
       elasticdump[`${type}Type`] = 'file'

--- a/lib/transports/s3.js
+++ b/lib/transports/s3.js
@@ -1,10 +1,12 @@
 const util = require('util')
+const JSONStream = require('JSONStream')
 const endOfLine = require('os').EOL
 const jsonParser = require('../jsonparser.js')
 const UploadStream = require('s3-stream-upload')
 const AWS = require('aws-sdk')
 const {Readable, PassThrough} = require('stream')
 const zlib = require('zlib')
+const s3urls = require('s3urls')
 
 class s3 {
   constructor (parent, file, options) {
@@ -12,6 +14,7 @@ class s3 {
     this.parent = parent
     this.file = file
     this.lineCounter = 0
+    this.localLineCounter = 0
     this.stream = null
     this.elementsToSkip = 0
 
@@ -31,7 +34,61 @@ class s3 {
   // accept callback
   // return (error, arr) where arr is an array of objects
   get (limit, offset, callback) {
-    throw Error('Not Yet Implemented')
+    this.thisGetLimit = limit
+    this.thisGetCallback = callback
+    this.localLineCounter = 0
+
+    if (this.lineCounter === 0) {
+      this.setupGet(offset)
+    } else {
+      this.metaStream.resume()
+    }
+
+    if (!this.metaStream.readable) {
+      this.completeBatch(null, this.thisGetCallback)
+    }
+  }
+
+  setupGet (offset) {
+    const self = this
+
+    self.bufferedData = []
+    self.stream = JSONStream.parse()
+
+    if (!self.elementsToSkip) { self.elementsToSkip = offset }
+
+    const params = s3urls.fromUrl(self.file)
+    self.metaStream = self._s3.getObject(params).createReadStream()
+
+    self.stream.on('data', elem => {
+      if (self.elementsToSkip > 0) {
+        self.elementsToSkip--
+      } else {
+        self.bufferedData.push(elem)
+      }
+
+      self.localLineCounter++
+      self.lineCounter++
+
+      if (self.localLineCounter === self.thisGetLimit) {
+        self.completeBatch(null, self.thisGetCallback)
+      }
+    })
+
+    self.stream.on('error', e => {
+      self.parent.emit('error', e)
+    })
+
+    self.stream.on('end', () => {
+      self.completeBatch(null, self.thisGetCallback, true)
+    })
+
+    let _throughStream = new PassThrough()
+    if (self.parent.options.s3Compress) {
+      _throughStream = zlib.createGunzip()
+    }
+
+    self.metaStream.pipe(_throughStream).pipe(self.stream)
   }
 
   // accept arr, callback where arr is an array of objects
@@ -59,9 +116,11 @@ class s3 {
         _throughStream = zlib.createGzip()
       }
 
+      const params = s3urls.fromUrl(self.file)
+
       self.stream.pipe(_throughStream).pipe(UploadStream(self._s3, {
-        Bucket: self.parent.options.s3Bucket,
-        Key: self.parent.options.s3RecordKey || `elastic_${new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')}_output.jsonl`
+        Bucket: params.Bucket || self.parent.options.s3Bucket,
+        Key: params.Key || self.parent.options.s3RecordKey || `elastic_${new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')}_output.jsonl`
       }))
         .on('error', function (err) {
           console.error(err)
@@ -108,6 +167,26 @@ class s3 {
     } else {
       this.stream.push(line + endOfLine)
     }
+  }
+
+  completeBatch (error, callback, streamEnded) {
+    const self = this
+    const data = []
+
+    self.metaStream.pause()
+
+    if (error) { return callback(error) }
+
+    // if we are skipping, have no data, and there is more to read we should continue on
+    if (!streamEnded && self.elementsToSkip > 0 && self.bufferedData.length === 0) {
+      return self.metaStream.resume()
+    }
+
+    while (self.bufferedData.length > 0) {
+      data.push(self.bufferedData.pop())
+    }
+
+    return callback(null, data)
   }
 }
 

--- a/lib/transports/s3.js
+++ b/lib/transports/s3.js
@@ -116,7 +116,14 @@ class s3 {
         _throughStream = zlib.createGzip()
       }
 
-      const params = s3urls.fromUrl(self.file)
+      let params = {
+        Bucket: null,
+        Key: null
+      }
+
+      if (self.file) {
+        params = s3urls.fromUrl(self.file)
+      }
 
       self.stream.pipe(_throughStream).pipe(UploadStream(self._s3, {
         Bucket: params.Bucket || self.parent.options.s3Bucket,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "request": "2.x.x",
     "requestretry": "^3.0.1",
     "s3-stream-upload": "2.0.2",
+    "s3urls": "^1.5.2",
     "socks5-http-client": "^1.0.4",
     "socks5-https-client": "^1.2.1"
   },


### PR DESCRIPTION
This pull request adds support to import data from S3.

I also improved the way to handle S3 parameters in input and output arguments.

It is now possible to define input or output argument as s3 connectionstring.

For example: 
```
elasticdump --input=s3://bucket_name/filename.json --output=http://localhost:9200/index_name --s3AccessKeyId "XXX" --s3SecretAccessKey "XXX"
```
For this i used the library `s3urls` to detect which transport should be used.

In theory the arguments `s3Bucket` and `s3RecordKey` are no longer needed.

My updated code has no breaking changes.

When my code is okay, i will update the docs.