### PR TITLE
First try to add custom certificate support.

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -49,7 +49,20 @@ const defaults = {
   prefix: '',
   suffix: '',
   transform: null,
-  searchBody: null
+  searchBody: null,
+  cert: null,
+  key: null,
+  pass: null,
+  ca: null,
+  tlsAuth: false,
+  'input-cert': null,
+  'input-key': null,
+  'input-pass': null,
+  'input-ca': null,
+  'output-cert': null,
+  'output-key': null,
+  'output-pass': null,
+  'output-ca': null
 }
 
 for (let i in defaults) {
@@ -185,7 +198,20 @@ const dump = () => {
     const mappingSettings = fork(path.join(__dirname, 'elasticdump'), [
       '--type=template',
       `--input=${input}`,
-      `--output=${outputTemplate}`
+      `--output=${outputTemplate}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     mappingSettings.on('close', code => {
@@ -204,7 +230,20 @@ const dump = () => {
     const mappingSettings = fork(path.join(__dirname, 'elasticdump'), [
       '--type=settings',
       `--input=${input}`,
-      `--output=${outputSettings}`
+      `--output=${outputSettings}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     mappingSettings.on('close', code => {
@@ -223,7 +262,20 @@ const dump = () => {
     const mappingChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=mapping',
       `--input=${input}`,
-      `--output=${outputMapping}`
+      `--output=${outputMapping}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     mappingChild.on('close', code => {
@@ -242,7 +294,20 @@ const dump = () => {
     const analyzerChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=analyzer',
       `--input=${input}`,
-      `--output=${outputAnalyzer}`
+      `--output=${outputAnalyzer}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     analyzerChild.on('close', code => {
@@ -261,7 +326,20 @@ const dump = () => {
     const aliasChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=alias',
       `--input=${input}`,
-      `--output=${outputAlias}`
+      `--output=${outputAlias}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     aliasChild.on('close', code => {
@@ -299,7 +377,20 @@ const dump = () => {
       `--searchBody=${options.searchBody}`,
       `--prefix=${options.prefix}`,
       `--suffix=${options.suffix}`,
-      `--support-big-int=${options['support-big-int']}`
+      `--support-big-int=${options['support-big-int']}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ].concat(_transform))
 
     dataChild.on('close', code => {
@@ -352,7 +443,20 @@ const load = () => {
     const settingsChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=template',
       `--input=${inputTemplate}`,
-      `--output=${output}`
+      `--output=${output}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     settingsChild.on('close', code => {
@@ -371,7 +475,20 @@ const load = () => {
     const settingsChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=settings',
       `--input=${inputSettings}`,
-      `--output=${output}`
+      `--output=${output}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     settingsChild.on('close', code => {
@@ -390,7 +507,20 @@ const load = () => {
     const analyzerChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=analyzer',
       `--input=${inputAnalyzer}`,
-      `--output=${output}`
+      `--output=${output}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     analyzerChild.on('close', code => {
@@ -409,7 +539,20 @@ const load = () => {
     const mappingChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=mapping',
       `--input=${inputMapping}`,
-      `--output=${output}`
+      `--output=${output}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     mappingChild.on('close', code => {
@@ -428,7 +571,20 @@ const load = () => {
     const aliasChild = fork(path.join(__dirname, 'elasticdump'), [
       '--type=alias',
       `--input=${inputAlias}`,
-      `--output=${output}`
+      `--output=${output}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ])
 
     aliasChild.on('close', code => {
@@ -466,7 +622,20 @@ const load = () => {
       `--offset=${options.offset}`,
       `--prefix=${options.prefix}`,
       `--suffix=${options.suffix}`,
-      `--support-big-int=${options['support-big-int']}`
+      `--support-big-int=${options['support-big-int']}`,
+      `--cert=${options.cert}`,
+      `--key=${options.key}`,
+      `--pass=${options.pass}`,
+      `--ca=${options.ca}`,
+      `--tlsAuth=${options.tlsAuth}`,
+      `--input-cert=${options['input-cert']}`,
+      `--input-key=${options['input-key']}`,
+      `--input-pass=${options['input-pass']}`,
+      `--input-ca=${options['input-ca']}`,
+      `--output-cert=${options['output-cert']}`,
+      `--output-key=${options['output-key']}`,
+      `--output-pass=${options['output-pass']}`,
+      `--output-ca=${options['output-ca']}`
     ].concat(_transform))
 
     dataChild.on('close', code => {


### PR DESCRIPTION
So here's the PR what I'm trying to achieve.

When I call elasticdump directly, it works as expected:

```
0369497e1886:/# elasticdump --input=https://elasticdump:elasticdump@elasticsearch:9200/testing* --output=/testi/testing.json --tlsAuth --cert=/cert.pem --key=/key.pem --ca=/ca.pem
Mon, 06 May 2019 08:20:44 GMT | starting dump
Mon, 06 May 2019 08:20:44 GMT | got 100 objects from source elasticsearch (offset: 0)
Mon, 06 May 2019 08:20:44 GMT | sent 100 objects to destination file, wrote 100
Mon, 06 May 2019 08:20:44 GMT | got 87 objects from source elasticsearch (offset: 100)
Mon, 06 May 2019 08:20:44 GMT | sent 87 objects to destination file, wrote 87
Mon, 06 May 2019 08:20:44 GMT | got 0 objects from source elasticsearch (offset: 187)
Mon, 06 May 2019 08:20:44 GMT | Total Writes: 187
Mon, 06 May 2019 08:20:44 GMT | dump complete
```

But when I call multielasticdump:
```
0369497e1886:/# multielasticdump --input=https://elasticdump:elasticdump@elasticsearch:9200 --output=/testi --match='^(?!\.).*$' --tlsAuth --cert=/cert.pem --key=/key.pem --ca=/ca.pem
Mon, 06 May 2019 08:29:24 GMT | We are performing : dump
Mon, 06 May 2019 08:29:24 GMT | options: {"debug":true,"parallel":2,"match":"^(?!\\.).*$","input":"https://elasticdump:elasticdump@elasticsearch:9200","output":"/testi","scrollTime":"10m","timeout":null,"limit":100,"offset":0,"direction":"dump","support-big-int":false,"ignoreAnalyzer":false,"ignoreData":false,"ignoreMapping":false,"ignoreSettings":false,"ignoreTemplate":false,"ignoreAlias":true,"ignoreType":[],"interval":1000,"prefix":"","suffix":"","transform":null,"searchBody":null,"cert":"/cert.pem","key":"/key.pem","pass":null,"ca":"/ca.pem","tlsAuth":true,"input-cert":null,"input-key":null,"input-pass":null,"input-ca":null,"output-cert":null,"output-key":null,"output-pass":null,"output-ca":null}
Mon, 06 May 2019 08:29:24 GMT | Error: unable to verify the first certificate
```