### PR TITLE
Reasonable concurrency defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,19 +250,19 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
                     (default: -1 -> no limit)
 --concurrency
                     How concurrent request is sent to a specified transport
-                    (default: Infinity -> no limit)       
+                    (default: 1)       
 --concurrencyInterval
                     The length of time in milliseconds before the interval count resets. Must be finite.
-                    (default: 0 -> no limit)       
+                    (default: 5000)       
 --intervalCap
                     The max number of transport request in the given interval of time.
-                    (default: Infinity -> no limit)
+                    (default: 5)
 --carryoverConcurrencyCount
                     Whether the task must finish in the given interval or will be carried over into the next interval count.
-                    (default: false)                                                                                       
+                    (default: true)                                                                                       
 --throttleInterval
                     Delay between getting data from an inputTransport and sending it to an outputTransport
-                     (default: 0 -> no limit)
+                     (default: 1)
 --debug
                     Display the elasticsearch commands being used
                     (default: false)

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -75,11 +75,11 @@ const defaults = {
   inputSocksPort: null,
   outputSocksProxy: null,
   outputSocksPort: null,
-  concurrency: Infinity,
-  throttleInterval: 0,
-  carryoverConcurrencyCount: false,
-  intervalCap: Infinity,
-  concurrencyInterval: 0,
+  concurrency: 1,
+  throttleInterval: 1,
+  carryoverConcurrencyCount: true,
+  intervalCap: 5,
+  concurrencyInterval: 5000,
   overwrite: false
 }
 const jsonParsedOpts = ['searchBody', 'headers', 'params']

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -27,23 +27,23 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 
 --concurrency
                     How concurrent request is sent to a specified transport
-                    (default: Infinity -> no limit)
+                    (default: 1)
 
 --concurrencyInterval
                     The length of time in milliseconds before the interval count resets. Must be finite.
-                    (default: 0 -> no limit)
+                    (default: 5000)
 
 --intervalCap
                     The max number of transport request in the given interval of time.
-                    (default: Infinity -> no limit)
+                    (default: 5)
 
 --carryoverConcurrencyCount
                     Whether the task must finish in the given interval or will be carried over into the next interval count.
-                    (default: false)
+                    (default: true)
 
 --throttleInterval
                     Delay between getting data from an inputTransport and sending it to an outputTransport
-                     (default: 0 -> no limit)
+                     (default: 1)
 
 --debug
                     Display the elasticsearch commands being used

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "JSONStream": "^1.3.5",
     "async": "^2.0.1",
-    "aws-sdk": "^2.524.0",
+    "aws-sdk": "^2.528.0",
     "aws4": "^1.8.0",
     "bytes": "^3.1.0",
     "decimal.js": "^10.2.0",
@@ -50,7 +50,7 @@
     "jsonpath": "1.0.2",
     "mocha": "latest",
     "should": "latest",
-    "standard": "^14.1.0"
+    "standard": "^14.2.0"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
Recent issues have been a result of the default concurrency value too high. This PR sets a reasonable default. 