### PR TITLE
fix `ignore-errors` flag behavior when the output transport fails.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -101,7 +101,14 @@ class TransportProcessor extends EventEmitter {
                     .then(resolve)
                 })
             })
-            .catch(reject)
+            .catch(err => {
+              this.emit('error', err)
+              if (!ignoreErrors) {
+                return reject(err)
+              } else {
+                return resolve(totalWrites)
+              }
+            })
         }
       })
     })


### PR DESCRIPTION
closes #612