### PR TITLE
#664 Enable support to specify AWS region for signing requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --awsService
                     Sets the AWS service that the signature will be generated for
                     (default: calculated from hostname or host)
+--awsRegion
+                    Sets the AWS region that the signature will be generated for
+                    (default: calculated from hostname or host)
 --support-big-int   
                     Support big integer numbers
 --retryAttempts  

--- a/bin/elasticdump
+++ b/bin/elasticdump
@@ -40,6 +40,7 @@ const defaults = {
   awsSecretAccessKey: null,
   awsIniFileProfile: null,
   awsService: null,
+  awsRegion: null,
   s3AccessKeyId: null,
   s3SecretAccessKey: null,
   s3Region: null,

--- a/lib/aws4signer.js
+++ b/lib/aws4signer.js
@@ -50,6 +50,10 @@ const aws4signer = (esRequest, parent) => {
     if (parent.options.awsService) {
       esRequest.service = parent.options.awsService
     }
+  
+    if(parent.options.awsRegion) {
+      esRequest.region = parent.options.awsRegion
+    }
 
     esRequest.headers = Object.assign({ host: urlObj.hostname, 'Content-Type': 'application/json' }, esRequest.headers)
     esRequest.path = `${urlObj.pathname}?${urlObj.searchParams.toString()}`

--- a/lib/help.txt
+++ b/lib/help.txt
@@ -151,6 +151,9 @@ Usage: elasticdump --input SOURCE --output DESTINATION [OPTIONS]
 --awsService
                     Sets the AWS service that the signature will be generated for
                     (default: calculated from hostname or host)
+--awsRegion
+                    Sets the AWS region that the signature will be generated for
+                    (default: calculated from hostname or host)
 --transform
                     A javascript, which will be called to modify documents
                     before writing it to destination. global variable 'doc'


### PR DESCRIPTION
Implemented adding a flag of --awsRegion to allow a user to specify which region to use when signing AWS requests.