### PR TITLE
Delete "searchWithTemplate" param

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -341,7 +341,6 @@ const dump = () => {
       `--limit=${options.limit}`,
       `--offset=${options.offset}`,
       `--searchBody=${options.searchBody}`,
-      `--searchWithTemplate=${options.searchWithTemplate}`
       `--prefix=${options.prefix}`,
       `--suffix=${options.suffix}`,
       `--support-big-int=${options['support-big-int']}`


### PR DESCRIPTION
The process crashes when this parameter is set