### PR TITLE
multielasticdump: handle error responses during /_aliases enumeration

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -172,6 +172,10 @@ if (options.direction === 'dump') {
       process.exit()
     }
     response = JSON.parse(response.body)
+    if ('error' in response) {
+      args.log('err', response.error.reason)
+      process.exit()
+    }
     if (!Array.isArray(response)) {
       response = Object.keys(response)
     }


### PR DESCRIPTION
ATM, when an error is returned during aliases enumeration (e.g., due to a lack of provided credentials) it is assumed that the response is an index / alias listing. This PR fixes this by handling the error.