### PR TITLE
multielasticdump: handle (error) HTTP status codes

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -172,6 +172,10 @@ if (options.direction === 'dump') {
       args.log('err', err)
       process.exit()
     }
+    if (response.statusCode >= 400) {
+      args.log('err', `Attempt to list /_aliases failed with status ${response.statusCode} ${response.statusMessage}`)
+      process.exit()
+    }
     response = JSON.parse(response.body)
     if ('error' in response) {
       args.log('err', response.error.reason)


### PR DESCRIPTION
Some more error handling in case /_aliases fails with a non-successful HTTP status code.