### PR TITLE
Update multielasticdump

### DIFF
--- a/bin/multielasticdump
+++ b/bin/multielasticdump
@@ -38,6 +38,7 @@ const defaults = {
   direction: 'dump', // default to dump
   'support-big-int': false,
   ignoreAnalyzer: true,
+  ignoreChildError: false,
   ignoreData: false,
   ignoreMapping: false,
   ignoreSettings: false,
@@ -148,7 +149,11 @@ const _fork = (params = [], file = 'elasticdump') => {
 const attachListeners = (clazz, cb) => {
   clazz.on('close', code => {
     if (code !== 0) {
-      return cb(new Error('CHILD PROCESS EXITED WITH ERROR.  Stopping process'))
+      if (!options.ignoreChildError) {
+        return cb(new Error('CHILD PROCESS EXITED WITH ERROR.  Stopping process'))
+      } else {
+        return cb()
+      }
     } else {
       return cb()
     }


### PR DESCRIPTION
add ignoreChildError option
so you can skip the client's errors.
Eg if you want to resume an aborted dump of the Elasticsearch.

Without this, it stops at the first index because it already exists as a file.