### PR TITLE
Fix "Deprecated field [_version] used" bug

### DIFF
--- a/lib/transports/elasticsearch.js
+++ b/lib/transports/elasticsearch.js
@@ -723,7 +723,7 @@ class elasticsearch {
 
       if (this.parent.options.handleVersion) {
         if (elem._version) {
-          actionMeta.index._version = elem._version
+          actionMeta.index.version = elem._version
         }
 
         if (this.parent.options.versionType) {


### PR DESCRIPTION
Fix this bug

    http://localhost:9200/_bulk] returned 1 warnings: [299 Elasticsearch-6.8.5-78990e9 "Deprecated field [_version] used, expected [version] instead"]